### PR TITLE
Fix playback, voice-leading, parsing, and export bugs

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
-    "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
+    "lint": "eslint . --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
     "test": "vitest",
     "test:coverage": "vitest run --coverage",

--- a/src/app/App.test.tsx
+++ b/src/app/App.test.tsx
@@ -2,32 +2,43 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent, act } from '@testing-library/react'
 import App from './App'
 
-// Mock child components
+// tone's ESM build uses extensionless imports that Node can't resolve, and
+// jsdom has no AudioContext — mock it out entirely. Nothing audio-related
+// runs in these tests because the components that use it are mocked below.
+vi.mock('tone', () => ({}))
+
+// Mock the heavy child components
 const mockPianoKeyboard = vi.fn()
-vi.mock('./features/keyboard/components/PianoKeyboard', () => ({
-  PianoKeyboard: (props: unknown) => {
+vi.mock('../features/keyboard/PianoKeyboard', () => ({
+  PianoKeyboard: (props: { activeNotes: number[] }) => {
     mockPianoKeyboard(props)
     return <div data-testid="piano-keyboard">Mock Piano</div>
   },
 }))
 
-vi.mock('./features/playback/components/PlaybackControls', () => ({
-  PlaybackControls: vi.fn().mockImplementation(({ onNotesChange }) => (
+vi.mock('../features/playback/PlaybackControls', () => ({
+  PlaybackControls: ({
+    onNotesChange,
+  }: {
+    onNotesChange: (notes: number[]) => void
+  }) => (
     <div
       data-testid="playback-controls"
       onClick={() => onNotesChange([60, 64, 67])}
     >
       Mock PlaybackControls
     </div>
-  )),
+  ),
 }))
 
-vi.mock('./features/instruments/components/InstrumentSelector', () => ({
-  InstrumentSelector: vi
-    .fn()
-    .mockImplementation(() => (
-      <div data-testid="instrument-selector">Mock InstrumentSelector</div>
-    )),
+vi.mock('../features/playback/InstrumentSelector', () => ({
+  InstrumentSelector: () => (
+    <div data-testid="instrument-selector">Mock InstrumentSelector</div>
+  ),
+}))
+
+vi.mock('../features/playback/SheetMusic', () => ({
+  SheetMusic: () => <div data-testid="sheet-music">Mock SheetMusic</div>,
 }))
 
 describe('App', () => {
@@ -38,30 +49,26 @@ describe('App', () => {
   it('renders header with app title', () => {
     render(<App />)
     expect(screen.getByText('Chord Flow')).toBeInTheDocument()
-  })
-
-  it('renders main content with title and description', () => {
-    render(<App />)
-    expect(screen.getByText('Giant Steps Voice Leading')).toBeInTheDocument()
-    expect(
-      screen.getByText(
-        "Optimal voice leading triads for Coltrane's Giant Steps."
-      )
-    ).toBeInTheDocument()
+    expect(screen.getByText('GitHub')).toBeInTheDocument()
   })
 
   it('renders all main components', () => {
     render(<App />)
-    expect(screen.getByTestId('piano-keyboard')).toBeInTheDocument()
+    expect(screen.getAllByTestId('piano-keyboard').length).toBeGreaterThan(0)
     expect(screen.getByTestId('playback-controls')).toBeInTheDocument()
     expect(screen.getByTestId('instrument-selector')).toBeInTheDocument()
+  })
+
+  it('renders the footer attribution', () => {
+    render(<App />)
+    expect(screen.getByText('@willdickerson')).toBeInTheDocument()
   })
 
   it('updates activeNotes state when PlaybackControls triggers onNotesChange', async () => {
     render(<App />)
 
     // Initially no active notes
-    expect(mockPianoKeyboard).toHaveBeenLastCalledWith(
+    expect(mockPianoKeyboard).toHaveBeenCalledWith(
       expect.objectContaining({ activeNotes: [] })
     )
 
@@ -71,7 +78,7 @@ describe('App', () => {
     })
 
     // Should update PianoKeyboard with new notes
-    expect(mockPianoKeyboard).toHaveBeenLastCalledWith(
+    expect(mockPianoKeyboard).toHaveBeenCalledWith(
       expect.objectContaining({ activeNotes: [60, 64, 67] })
     )
   })

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -19,13 +19,12 @@ function ChartRoute() {
   const [activeNotes, setActiveNotes] = useState<number[]>([])
   const [isEditing, setIsEditing] = useState(false)
   const [activeDisplay, setActiveDisplay] = useState<DisplayOption>('keyboard')
-  const [currentChords, setCurrentChords] = useState<string[]>([])
   const [initialChartData] = useState(() => {
     if (encodedData) {
       try {
         const data = decodeChartData(encodedData)
+        // Must happen before child mount effects generate the first sequence.
         audioService.setCurrentChordNames(data.chords)
-        setCurrentChords(data.chords)
         return data
       } catch (error) {
         console.error('Failed to decode chart data:', error)
@@ -33,6 +32,9 @@ function ChartRoute() {
     }
     return null
   })
+  const [currentChords, setCurrentChords] = useState<string[]>(
+    () => initialChartData?.chords ?? []
+  )
 
   return (
     <div className="flex-1">

--- a/src/common/utils/chordUtils.ts
+++ b/src/common/utils/chordUtils.ts
@@ -29,6 +29,8 @@ export function parseChord(chord: string): {
     chordType = 'dim'
   } else if (chordType.includes('aug') || chordType.includes('+')) {
     chordType = 'aug'
+  } else if (chordType.toLowerCase().includes('mmaj')) {
+    chordType = 'm' // minor-major 7th chord -> minor triad
   } else if (chordType.includes('maj7') || chordType.includes('maj')) {
     chordType = 'M' // major 7th chord -> major triad
   } else if (chordType.startsWith('m')) {
@@ -160,6 +162,8 @@ function parseSeventhChord(chord: string): {
   const standardizedRoot = ENHARMONIC_MAP[originalRoot] || originalRoot
   const suffix = match[2] || ''
 
+  const lower = suffix.toLowerCase()
+
   let chordType: string
   if (suffix.includes('m7b5') || suffix.includes('ø')) {
     chordType = 'm7b5'
@@ -167,16 +171,20 @@ function parseSeventhChord(chord: string): {
     chordType = 'dim7'
   } else if (suffix.includes('dim') || suffix.includes('°')) {
     chordType = 'm7b5' // half-dim is the most common interpretation of a bare "dim" in a 7th-chord context
-  } else if (suffix.includes('mMaj7') || suffix.includes('mM7')) {
+  } else if (lower.includes('mmaj7') || suffix.includes('mM7')) {
     chordType = 'mMaj7'
-  } else if (suffix.includes('maj7') || suffix.includes('M7')) {
+  } else if (lower.includes('maj7') || suffix.includes('M7')) {
     chordType = 'maj7'
-  } else if (suffix.startsWith('m')) {
-    chordType = 'm7'
-  } else if (suffix.includes('7')) {
-    chordType = '7'
+  } else if (lower.includes('maj')) {
+    chordType = 'maj7' // maj9, maj13, etc. all carry a major 7th
   } else if (suffix.includes('aug') || suffix.includes('+')) {
-    chordType = '7' // closest 4-note approximation; aug7 not yet modeled
+    chordType = '7' // closest 4-note approximation; aug7 not yet modeled (checked before the minor test so "maug" isn't read as minor)
+  } else if (suffix.startsWith('m')) {
+    chordType = 'm7' // m6, m9, m11, etc. -> minor 7th
+  } else if (lower.includes('add') || suffix.includes('6')) {
+    chordType = 'maj7' // add9 / 6 / 69 chords have no b7 — major quality
+  } else if (/7|9|11|13/.test(suffix)) {
+    chordType = '7' // dominant extensions/alterations: 9, 13, 7b9, 7alt, ...
   } else {
     chordType = 'maj7' // bare major chord -> major 7th in seventh mode
   }

--- a/src/common/utils/midiUtils.ts
+++ b/src/common/utils/midiUtils.ts
@@ -11,8 +11,9 @@ export function midiNoteToName(
   const octaveDiff = midiNote - middleC
   let octaveMarks = ''
   if (octaveDiff < 0) {
-    // Add commas for each octave below middle C
-    octaveMarks = ','.repeat(Math.floor(Math.abs(octaveDiff) / 12) + 1)
+    // Add commas for each octave below middle C (ceil so an exact octave
+    // below gets one comma, not two)
+    octaveMarks = ','.repeat(Math.ceil(Math.abs(octaveDiff) / 12))
   } else if (octaveDiff >= 12) {
     const octaveCount = Math.floor(octaveDiff / 12)
     octaveMarks = "'".repeat(octaveCount)
@@ -193,13 +194,16 @@ export const downloadMidiFile = (
 
   // Set time signature
   if (isArpeggiating) {
+    // One beat per arpeggiated note, so a measure spans one chord
+    // (3 beats for triads, 4 for seventh chords)
+    const notesPerChord = sequence.chords[0]?.midiNotes.length || 3
     trackEvents.push([
       0, // delta time
       0xff,
       0x58,
       0x04, // time signature meta event
-      0x03, // numerator (3)
-      0x02, // denominator (2^2 = 4, so 3/4 time)
+      notesPerChord, // numerator
+      0x02, // denominator (2^2 = 4, so notesPerChord/4 time)
       0x18, // clocks per metronome click (24 MIDI clocks per quarter note)
       0x08, // number of 32nd notes per 24 MIDI clocks (8)
     ])

--- a/src/common/utils/seventhChords.test.ts
+++ b/src/common/utils/seventhChords.test.ts
@@ -63,6 +63,44 @@ describe('seventh chord generation', () => {
     const root = generateSeventhChords('C', 'close')[0].split(' ')
     expect(root.sort().join(',')).toBe(['B', 'C', 'E', 'G'].sort().join(','))
   })
+
+  it('treats extended dominants (9, 13) as dominant 7ths, not maj7', () => {
+    // D9 carries a flat 7 (C natural), not C#
+    const d9 = generateSeventhChords('D9', 'close')[0].split(' ')
+    expect(d9.sort().join(',')).toBe(['A', 'C', 'D', 'Gb'].sort().join(','))
+
+    const g13 = generateSeventhChords('G13', 'close')[0].split(' ')
+    expect(g13.sort().join(',')).toBe(['B', 'D', 'F', 'G'].sort().join(','))
+  })
+
+  it('treats maj9 / maj13 as major 7th quality', () => {
+    const cmaj9 = generateSeventhChords('Cmaj9', 'close')[0].split(' ')
+    expect(cmaj9.sort().join(',')).toBe(['B', 'C', 'E', 'G'].sort().join(','))
+  })
+
+  it('treats 6 and add9 chords as major quality (no flat 7)', () => {
+    const c6 = generateSeventhChords('C6', 'close')[0].split(' ')
+    expect(c6.sort().join(',')).toBe(['B', 'C', 'E', 'G'].sort().join(','))
+
+    const cadd9 = generateSeventhChords('Cadd9', 'close')[0].split(' ')
+    expect(cadd9.sort().join(',')).toBe(['B', 'C', 'E', 'G'].sort().join(','))
+  })
+
+  it('treats m6 / m9 as minor 7th quality', () => {
+    const fm6 = generateSeventhChords('Fm6', 'close')[0].split(' ')
+    expect(fm6.sort().join(',')).toBe(['Ab', 'C', 'Eb', 'F'].sort().join(','))
+  })
+
+  it('does not read augmented chords as minor', () => {
+    // "Dmaug" appears in the bundled charts; the "m" belongs to "maug", not minor
+    const dmaug = generateSeventhChords('Dmaug', 'close')[0].split(' ')
+    expect(dmaug.sort().join(',')).toBe(['A', 'C', 'D', 'Gb'].sort().join(','))
+  })
+
+  it('parses minor-major 7th chords regardless of case', () => {
+    const cmmaj7 = generateSeventhChords('Cmmaj7', 'close')[0].split(' ')
+    expect(cmmaj7.sort().join(',')).toBe(['B', 'C', 'Eb', 'G'].sort().join(','))
+  })
 })
 
 describe('findAllVoicingsInRange (N-voice)', () => {

--- a/src/features/playback/SheetMusic.tsx
+++ b/src/features/playback/SheetMusic.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react'
 import ABCJS from 'abcjs'
 import { midiNoteToName } from '../../common/utils/midiUtils'
-import { usePlaybackState } from './usePlaybackState'
 import { Triad } from '../../common/types'
 import { audioService } from '../../services/audioService'
 
@@ -19,8 +18,6 @@ export const SheetMusic: React.FC<SheetMusicProps> = ({
   const containerRef = useRef<HTMLDivElement>(null)
   const [isMobile, setIsMobile] = useState(window.innerWidth <= 768)
   const previousChordsRef = useRef<string[]>([])
-
-  const { sequence, currentPosition } = usePlaybackState(() => {})
 
   useEffect(() => {
     const safeCurrentChords = currentChords ?? []
@@ -122,7 +119,7 @@ export const SheetMusic: React.FC<SheetMusicProps> = ({
       clearTimeout(timeoutId)
       window.removeEventListener('resize', centerStaff)
     }
-  }, [sequence, currentPosition, isMobile])
+  }, [activeNotes, currentChords, isMobile])
 
   useEffect(() => {
     if (!divRef.current) {
@@ -131,7 +128,7 @@ export const SheetMusic: React.FC<SheetMusicProps> = ({
 
     let abcNotation: string
 
-    const currentSequence = audioService.generateOptimalSequence()
+    const currentSequence = audioService.getCurrentSequence()
     const position = audioService.getCurrentPosition()
 
     if (!currentSequence || currentSequence.length === 0) {

--- a/src/features/playback/usePlaybackState.ts
+++ b/src/features/playback/usePlaybackState.ts
@@ -33,26 +33,32 @@ export const usePlaybackState = (onNotesChange: (notes: number[]) => void) => {
     useState<AnyVoiceLeadingState>(DEFAULT_TRIAD_VOICES)
   const displayedNotesRef = useRef<number[]>([])
 
-  const generateSequence = useCallback(async () => {
-    try {
-      setIsGenerating(true)
-      setError(null)
+  const generateSequence = useCallback(
+    // setVoiceLeadingState hasn't flushed when callers regenerate right after
+    // changing voices, so the new state must be passed in explicitly.
+    async (voicesOverride?: AnyVoiceLeadingState) => {
+      try {
+        setIsGenerating(true)
+        setError(null)
 
-      const newSequence =
-        audioService.generateOptimalSequence(voiceLeadingState)
-      setSequence(newSequence)
-      setCurrentPosition(0)
-      displayedNotesRef.current = []
-      onNotesChange([])
-      return newSequence
-    } catch (err) {
-      console.error('Error generating sequence:', err)
-      setError('Failed to generate sequence')
-      return null
-    } finally {
-      setIsGenerating(false)
-    }
-  }, [voiceLeadingState, onNotesChange])
+        const newSequence = audioService.generateOptimalSequence(
+          voicesOverride ?? voiceLeadingState
+        )
+        setSequence(newSequence)
+        setCurrentPosition(0)
+        displayedNotesRef.current = []
+        onNotesChange([])
+        return newSequence
+      } catch (err) {
+        console.error('Error generating sequence:', err)
+        setError('Failed to generate sequence')
+        return null
+      } finally {
+        setIsGenerating(false)
+      }
+    },
+    [voiceLeadingState, onNotesChange]
+  )
 
   const updateChordSequence = useCallback(
     (chordNames: string[]) => {
@@ -76,31 +82,29 @@ export const usePlaybackState = (onNotesChange: (notes: number[]) => void) => {
       await audioService.initialize()
 
       if (!isPlaying) {
-        if (!sequence || sequence.length === 0) {
-          const newSequence = await generateSequence()
-          if (!newSequence) {
+        let currentSequence = sequence
+        if (!currentSequence || currentSequence.length === 0) {
+          currentSequence = await generateSequence()
+          if (!currentSequence) {
             console.error('Failed to generate sequence')
             setError('Failed to generate sequence')
             return
           }
-          setSequence(newSequence)
         }
 
         setIsPlaying(true)
-
-        const currentSequence = sequence || (await generateSequence())
-        if (!currentSequence) return
 
         audioService.startPlayback(
           currentSequence,
           currentPosition,
           () => {
+            // Only reached on natural completion (stopPlayback never calls
+            // onComplete), so rewind for the next play-through.
             setIsPlaying(false)
-            if (!audioService.shouldStop) {
-              setCurrentPosition(0)
-              displayedNotesRef.current = []
-              onNotesChange([])
-            }
+            setCurrentPosition(0)
+            audioService.setPosition(0)
+            displayedNotesRef.current = []
+            onNotesChange([])
           },
           notes => {
             displayedNotesRef.current = notes
@@ -160,7 +164,7 @@ export const usePlaybackState = (onNotesChange: (notes: number[]) => void) => {
         setIsPlaying(false)
       }
       setCurrentPosition(0)
-      generateSequence()
+      generateSequence(voices)
     },
     [isPlaying, generateSequence]
   )
@@ -177,7 +181,7 @@ export const usePlaybackState = (onNotesChange: (notes: number[]) => void) => {
         setIsPlaying(false)
       }
       setCurrentPosition(0)
-      generateSequence()
+      generateSequence(defaults)
     },
     [isPlaying, generateSequence]
   )

--- a/src/services/audioConstants.ts
+++ b/src/services/audioConstants.ts
@@ -6,7 +6,7 @@ export const SEQUENCE_RANGES = {
 } as const
 
 export const AUDIO_DEFAULTS = {
-  VOLUME: -12,
+  VOLUME: 100, // 0-100 slider scale, converted to dB via gainToDb(volume / 100)
   CHORD_DURATION: 500,
   IS_ARPEGGIATING: true,
   IS_LOOPING: false,

--- a/src/services/audioService.ts
+++ b/src/services/audioService.ts
@@ -67,6 +67,7 @@ export class AudioService {
   private currentMidiNotes: number[] = []
   private currentChordNames: string[] = defaultChordNames
   private currentTriads: { [key: string]: Inversion[] } = defaultTriads
+  private currentSequence: Triad[] = []
   private triadType: TriadType = AUDIO_DEFAULTS.TRIAD_TYPE
   private chordMode: ChordMode = 'triad'
   private arpeggioType: ArpeggioType = AUDIO_DEFAULTS.ARPEGGIO_TYPE
@@ -134,14 +135,27 @@ export class AudioService {
     return this.volume
   }
 
+  // The guitar samples are much louder than the others, so they get a fixed
+  // dB offset that has to survive user volume changes.
+  private static readonly INSTRUMENT_DB_OFFSETS: Record<InstrumentType, number> =
+    {
+      synth: 0,
+      piano: 0,
+      guitar: -12,
+    }
+
+  private applyVolume(type: InstrumentType): void {
+    const instrument = this.instruments[type]
+    if (instrument) {
+      instrument.volume.value =
+        Tone.gainToDb(this.volume / 100) +
+        AudioService.INSTRUMENT_DB_OFFSETS[type]
+    }
+  }
+
   setVolume(value: number): void {
     this.volume = value
-    const normalizedVolume = value / 100
-    Object.values(this.instruments).forEach(instrument => {
-      if (instrument) {
-        instrument.volume.value = Tone.gainToDb(normalizedVolume)
-      }
-    })
+    INSTRUMENT_TYPES.forEach(type => this.applyVolume(type))
   }
 
   getCurrentPosition(): number {
@@ -155,6 +169,7 @@ export class AudioService {
   setCurrentChordNames(chordNames: string[]): void {
     this.currentChordNames = chordNames
     this.currentTriads = buildVoicings(chordNames, this.chordMode, this.triadType)
+    this.currentSequence = []
   }
 
   getInitialChordDuration(): number {
@@ -189,9 +204,7 @@ export class AudioService {
         .set({ volume: -8 })
         .toDestination()
 
-      if (this.instruments.synth) {
-        this.instruments.synth.volume.value = Tone.gainToDb(this.volume / 100)
-      }
+      this.applyVolume('synth')
 
       this.isInitialized = true
     } catch (err) {
@@ -239,11 +252,7 @@ export class AudioService {
           release: 1.5,
           baseUrl: 'https://tonejs.github.io/audio/salamander/',
           onload: () => {
-            if (this.instruments.piano) {
-              this.instruments.piano.volume.value = Tone.gainToDb(
-                this.volume / 100
-              )
-            }
+            this.applyVolume('piano')
             resolve()
           },
         }).toDestination()
@@ -275,11 +284,7 @@ export class AudioService {
           baseUrl:
             'https://raw.githubusercontent.com/nbrosowsky/tonejs-instruments/master/samples/guitar-nylon/',
           onload: () => {
-            if (this.instruments.guitar) {
-              this.instruments.guitar.volume.value = Tone.gainToDb(
-                (this.volume - 75) / 100
-              )
-            }
+            this.applyVolume('guitar')
             resolve()
           },
         }).connect(reverb)
@@ -470,9 +475,8 @@ export class AudioService {
       try {
         await new Promise(resolve => {
           const timeout = setTimeout(() => {
-            if (!this._shouldStop) {
-              resolve('completed')
-            }
+            clearInterval(checkInterval)
+            resolve('completed')
           }, duration)
           const checkInterval = setInterval(() => {
             if (this._shouldStop) {
@@ -584,12 +588,20 @@ export class AudioService {
           ]
         : [voiceLeadingState.bass, voiceLeadingState.middle, voiceLeadingState.high]
 
-    return generateOptimalVoiceLeadingSequence(
+    this.currentSequence = generateOptimalVoiceLeadingSequence(
       this.currentChordNames,
       midiRange,
       this.currentTriads,
       selections
     )
+    return this.currentSequence
+  }
+
+  // Last sequence produced by generateOptimalSequence. Lets display components
+  // read the sequence that's actually playing instead of re-running the
+  // optimizer (which is expensive and ignores the user's voice selections).
+  getCurrentSequence(): Triad[] {
+    return this.currentSequence
   }
 
   setTriadType(type: TriadType): void {
@@ -599,6 +611,7 @@ export class AudioService {
       this.chordMode,
       type
     )
+    this.currentSequence = []
   }
 
   setChordMode(mode: ChordMode): void {
@@ -608,6 +621,7 @@ export class AudioService {
       mode,
       this.triadType
     )
+    this.currentSequence = []
   }
 
   getChordMode(): ChordMode {


### PR DESCRIPTION
Fixes the issues found in a bug sweep of the codebase.

## Bug fixes

- **Voice-leading toggles were one interaction behind.** `generateSequence` closed over the previous `voiceLeadingState`, so toggling a voice (or switching chord mode) regenerated the sequence with the old selections. In seventh mode this also silently excluded the soprano voice from optimization. The new voices are now passed to `generateSequence` explicitly.
- **Play after completion replayed only the last chord.** The position-reset branch in `onComplete` was dead code (`shouldStop` is set before `onComplete` fires), so a finished progression resumed at its final chord. `onComplete` only fires on natural completion, so it now always rewinds to the start.
- **Interval leak during playback.** `playTriad`'s 100 ms stop-check interval was only cleared when playback stopped; with looping enabled, every chord of every pass leaked another interval.
- **Notation view re-ran the optimizer constantly, with the wrong settings.** `SheetMusic` called `generateOptimalSequence()` (default triad voice weights) on every note change — a full graph build + Dijkstra several times a second that could also disagree with the sequence actually playing. The service now caches the last generated sequence and the notation reads that; SheetMusic's disconnected `usePlaybackState` instance is removed.
- **Extended chord qualities parsed wrong.** `D9`/`G13` became maj7 chords (major 7th instead of the dominant b7), `maj9` was read as *minor*, and `Dmaug` was read as minor too. 6/69/add9 chords are now treated as major quality. Covered by new regression tests.
- **Changing volume blew away the guitar's level offset,** making it jump ~12 dB louder relative to the other instruments. Per-instrument dB offsets now survive volume changes. Also fixed `AUDIO_DEFAULTS.VOLUME = -12`, which was dB units in a field used on the 0–100 slider scale (`gainToDb(-0.12)` = NaN).
- **MIDI export:** octave-comma off-by-one at exact octave boundaries, and arpeggio exports hard-coded 3/4 time (wrong for four-note seventh chords).
- **`ChartRoute` called setState during render** inside a `useState` initializer.

## Tooling repairs

- `App.test.tsx` couldn't run at all (tone ESM resolution failure) and was stale: it mocked component paths that no longer exist and asserted removed UI text. Rewritten against the current app; suite passes (23 tests total).
- `npm run lint` passed eslint 9 the removed `--ext` flag and died before linting anything.

## Verification

- `tsc`, `eslint`, `vite build`, and `vitest` (23/23) all pass.
- Verified in the browser: voice toggles regenerate the sequence on the first click, notation view renders from the cached sequence, playback completes and replays from the first chord, and seventh mode switches cleanly with 4 voice controls — no console errors.