### PR TITLE
Add guitar tablature display

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -8,6 +8,7 @@ import { decodeChartData } from '../common/utils/urlUtils'
 import { audioService } from '../services/audioService'
 import { InfoModal } from '../features/info/InfoModal'
 import { SheetMusic } from '../features/playback/SheetMusic'
+import { GuitarTab } from '../features/playback/GuitarTab'
 import {
   DisplayControls,
   DisplayOption,
@@ -66,6 +67,21 @@ function ChartRoute() {
         >
           <div className="flex justify-center">
             <SheetMusic
+              activeNotes={activeNotes}
+              currentChords={currentChords}
+            />
+          </div>
+        </div>
+
+        <div
+          className={`absolute w-full transition-opacity duration-200 ${
+            activeDisplay === 'tablature' && !isEditing
+              ? 'opacity-100'
+              : 'opacity-0 pointer-events-none'
+          }`}
+        >
+          <div className="flex justify-center">
+            <GuitarTab
               activeNotes={activeNotes}
               currentChords={currentChords}
             />

--- a/src/common/utils/tabUtils.test.ts
+++ b/src/common/utils/tabUtils.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from 'vitest'
+import {
+  generateTabSequence,
+  STANDARD_TUNING,
+  TabFingering,
+} from './tabUtils'
+
+const soundedNotes = (fingering: TabFingering): number[] =>
+  fingering.flatMap((fret, string) =>
+    fret === null ? [] : [STANDARD_TUNING[string] + fret]
+  )
+
+const frettedFrets = (fingering: TabFingering): number[] =>
+  fingering.filter((f): f is number => f !== null && f > 0)
+
+const fretSpan = (fingering: TabFingering): number => {
+  const fretted = frettedFrets(fingering)
+  return fretted.length ? Math.max(...fretted) - Math.min(...fretted) : 0
+}
+
+const handPosition = (fingering: TabFingering): number => {
+  const fretted = frettedFrets(fingering)
+  return fretted.length ? Math.min(...fretted) : 0
+}
+
+describe('generateTabSequence', () => {
+  it('reproduces every pitch on a distinct string within the fret range', () => {
+    const chords = [
+      [48, 52, 55], // C major triad
+      [45, 52, 57], // A minor voicing
+      [43, 50, 55, 59], // G chord tones
+      [40, 47, 52, 56], // E7 fragment
+    ]
+    const tabs = generateTabSequence(chords)
+
+    tabs.forEach((fingering, i) => {
+      expect(fingering).not.toBeNull()
+      const sounded = soundedNotes(fingering!).sort((a, b) => a - b)
+      expect(sounded).toEqual([...chords[i]].sort((a, b) => a - b))
+      fingering!.forEach(fret => {
+        if (fret !== null) {
+          expect(fret).toBeGreaterThanOrEqual(0)
+          expect(fret).toBeLessThanOrEqual(15)
+        }
+      })
+    })
+  })
+
+  it('keeps every shape within a playable hand span', () => {
+    // A realistic run: Giant Steps' first chords voiced in the app's range
+    const chords = [
+      [47, 51, 54], // B major
+      [45, 50, 54], // D7 fragment
+      [43, 47, 50], // G major
+      [46, 50, 53], // Bb7 fragment
+      [43, 46, 51], // Eb fragment
+    ]
+    const tabs = generateTabSequence(chords)
+    tabs.forEach(fingering => {
+      expect(fingering).not.toBeNull()
+      expect(fretSpan(fingering!)).toBeLessThanOrEqual(4)
+    })
+  })
+
+  it('prefers open position for open-friendly chords', () => {
+    // C3 E3 G3 is the middle of the open C shape: A3 D2 G0
+    const [c] = generateTabSequence([[48, 52, 55]])
+    expect(c).toEqual([null, 3, 2, 0, null, null])
+  })
+
+  it('keeps the same fingering for repeated chords', () => {
+    const chord = [48, 52, 55]
+    const tabs = generateTabSequence([chord, chord, chord])
+    expect(tabs[1]).toEqual(tabs[0])
+    expect(tabs[2]).toEqual(tabs[0])
+  })
+
+  it('minimizes hand movement between consecutive chords', () => {
+    // Each chord playable in several positions; consecutive choices should
+    // never ask the hand to leap more than a few frets.
+    const chords = [
+      [48, 52, 55],
+      [50, 53, 57],
+      [52, 55, 59],
+      [50, 53, 57],
+      [48, 52, 55],
+    ]
+    const tabs = generateTabSequence(chords)
+    for (let i = 1; i < tabs.length; i++) {
+      const jump = Math.abs(handPosition(tabs[i]!) - handPosition(tabs[i - 1]!))
+      expect(jump).toBeLessThanOrEqual(4)
+    }
+  })
+
+  it('shifts a voicing up an octave when it is unplayable in place', () => {
+    // E2 G#2 B2: both E2 and G#2 only exist on the low E string, so the
+    // voicing is unplayable in place — but it sits nicely an octave up.
+    const [fingering] = generateTabSequence([[40, 44, 47]])
+    expect(fingering).not.toBeNull()
+    const sounded = soundedNotes(fingering!).sort((a, b) => a - b)
+    expect(sounded).toEqual([52, 56, 59])
+    expect(fretSpan(fingering!)).toBeLessThanOrEqual(4)
+  })
+
+  it('re-voices unplayable cluster voicings, preserving pitch classes and bass', () => {
+    // A real case from seventh mode: Bmaj7 voiced A#2 B2 D#3 F#3 —
+    // fine on a keyboard, impossible on six strings even an octave up.
+    const chord = [46, 47, 51, 54]
+    const [fingering] = generateTabSequence([chord])
+    expect(fingering).not.toBeNull()
+
+    const sounded = soundedNotes(fingering!).sort((a, b) => a - b)
+    const pitchClasses = (notes: number[]) =>
+      [...new Set(notes.map(n => n % 12))].sort((a, b) => a - b)
+    expect(pitchClasses(sounded)).toEqual(pitchClasses(chord))
+    // The bass pitch class survives the re-voicing
+    expect(sounded[0] % 12).toBe(chord[0] % 12)
+    expect(fretSpan(fingering!)).toBeLessThanOrEqual(5)
+  })
+
+  it('returns null only for degenerate input without breaking the rest', () => {
+    const chords = [
+      [48, 52, 55],
+      [40, 41, 42, 43, 44, 45, 46], // more notes than strings
+      [48, 52, 55],
+    ]
+    const tabs = generateTabSequence(chords)
+    expect(tabs[0]).not.toBeNull()
+    expect(tabs[1]).toBeNull()
+    expect(tabs[2]).not.toBeNull()
+  })
+
+  it('handles four-note seventh chords from the app range', () => {
+    const chords = [
+      [40, 47, 51, 56], // E maj7 fragment spanning the low strings
+      [45, 52, 56, 59], // A maj7 fragment
+    ]
+    const tabs = generateTabSequence(chords)
+    tabs.forEach((fingering, i) => {
+      expect(fingering).not.toBeNull()
+      expect(soundedNotes(fingering!).sort((a, b) => a - b)).toEqual(
+        [...chords[i]].sort((a, b) => a - b)
+      )
+      expect(fretSpan(fingering!)).toBeLessThanOrEqual(4)
+    })
+  })
+
+  it('returns an empty array for an empty sequence', () => {
+    expect(generateTabSequence([])).toEqual([])
+  })
+})

--- a/src/common/utils/tabUtils.ts
+++ b/src/common/utils/tabUtils.ts
@@ -1,0 +1,260 @@
+// Guitar tablature fingering assignment.
+//
+// Any given pitch can be played in several places on the fretboard, so
+// choosing where to play a chord is an optimization problem. Each chord's
+// candidate fingerings are scored for playability (fret span, hand position,
+// muted inner strings), then dynamic programming picks the sequence of
+// fingerings that minimizes shape cost plus hand movement between chords —
+// the fretting-hand analogue of the voice-leading optimizer.
+//
+// Not every keyboard voicing is playable on six strings (close-position
+// clusters low on the neck, for instance), so candidates are generated in
+// tiers of decreasing faithfulness: the exact voicing, the voicing an octave
+// up (guitar sounds an octave below written pitch, so this is idiomatic),
+// and finally a re-voicing of the same pitch classes over the same bass.
+// Later tiers carry penalties so the most faithful playable shape wins.
+
+// Standard tuning, low to high: E2 A2 D3 G3 B3 E4
+export const STANDARD_TUNING = [40, 45, 50, 55, 59, 64]
+export const STRING_NAMES = ['E', 'A', 'D', 'G', 'B', 'e']
+const MAX_FRET = 15
+const LOWEST_NOTE = STANDARD_TUNING[0]
+const HIGHEST_NOTE = STANDARD_TUNING[STANDARD_TUNING.length - 1] + MAX_FRET
+
+const OCTAVE_SHIFT_PENALTY = 2
+const REVOICE_PENALTY = 4
+
+// One chord's fingering: fret number per string (index 0 = low E),
+// or null where the string isn't played.
+export type TabFingering = (number | null)[]
+
+const frettedFrets = (frets: number[]): number[] => frets.filter(f => f > 0)
+
+// Fret the hand sits at: the lowest fretted note, 0 if everything is open.
+function handPosition(frets: number[]): number {
+  const fretted = frettedFrets(frets)
+  return fretted.length ? Math.min(...fretted) : 0
+}
+
+// How hard a shape is to hold, independent of context.
+function shapeCost(strings: number[], frets: number[]): number {
+  const fretted = frettedFrets(frets)
+  const span = fretted.length
+    ? Math.max(...fretted) - Math.min(...fretted)
+    : 0
+
+  // Muted strings between the outermost sounded strings are awkward to strum
+  const innerGaps =
+    Math.max(...strings) - Math.min(...strings) + 1 - strings.length
+
+  // Average fret pulls gently toward open position
+  const avgFret = frets.reduce((a, b) => a + b, 0) / frets.length
+
+  return span * 2 + (span >= 4 ? 4 : 0) + innerGaps * 0.75 + avgFret * 0.25
+}
+
+// Cost of moving the fretting hand between consecutive chords.
+function transitionCost(prevFrets: number[], nextFrets: number[]): number {
+  return Math.abs(handPosition(prevFrets) - handPosition(nextFrets))
+}
+
+type Candidate = {
+  strings: number[] // string index per note, ascending
+  frets: number[] // fret per note, parallel to strings
+  cost: number
+}
+
+// Enumerate every way to place the chord's notes (ascending) on strictly
+// ascending strings — non-crossing assignments only, which is how chords
+// are actually voiced on the instrument.
+function findCandidates(midiNotes: number[], maxSpan: number): Candidate[] {
+  const candidates: Candidate[] = []
+
+  const recurse = (noteIndex: number, minString: number, acc: number[]) => {
+    if (noteIndex === midiNotes.length) {
+      const frets = acc.map((s, i) => midiNotes[i] - STANDARD_TUNING[s])
+      const fretted = frettedFrets(frets)
+      const span = fretted.length
+        ? Math.max(...fretted) - Math.min(...fretted)
+        : 0
+      if (span <= maxSpan) {
+        candidates.push({
+          strings: [...acc],
+          frets,
+          cost: shapeCost(acc, frets),
+        })
+      }
+      return
+    }
+    for (let s = minString; s < STANDARD_TUNING.length; s++) {
+      const fret = midiNotes[noteIndex] - STANDARD_TUNING[s]
+      if (fret < 0 || fret > MAX_FRET) continue
+      acc.push(s)
+      recurse(noteIndex + 1, s + 1, acc)
+      acc.pop()
+    }
+  }
+
+  recurse(0, 0, [])
+  return candidates
+}
+
+function toFingering(candidate: Candidate): TabFingering {
+  const fingering: TabFingering = STANDARD_TUNING.map(() => null)
+  candidate.strings.forEach((s, i) => {
+    fingering[s] = candidate.frets[i]
+  })
+  return fingering
+}
+
+const withPenalty = (candidates: Candidate[], penalty: number): Candidate[] =>
+  candidates.map(c => ({ ...c, cost: c.cost + penalty }))
+
+// All ways to place the chord's pitch classes on the fretboard as an
+// ascending set of distinct pitches, keeping the original bass pitch class
+// on the bottom so the arrangement's bass line survives.
+function revoicedPitchSets(midiNotes: number[]): number[][] {
+  const bassPc = midiNotes[0] % 12
+  const upperPcs = midiNotes.slice(1).map(n => n % 12)
+
+  const optionsForPc = (pc: number, min: number): number[] => {
+    const options: number[] = []
+    for (let midi = min; midi <= HIGHEST_NOTE; midi++) {
+      if (midi % 12 === pc) options.push(midi)
+    }
+    return options
+  }
+
+  const sets = new Map<string, number[]>()
+  for (const bass of optionsForPc(bassPc, LOWEST_NOTE)) {
+    const recurse = (pcIndex: number, acc: number[]) => {
+      if (pcIndex === upperPcs.length) {
+        const set = [bass, ...acc].sort((a, b) => a - b)
+        if (new Set(set).size === set.length) {
+          sets.set(set.join(','), set)
+        }
+        return
+      }
+      for (const midi of optionsForPc(upperPcs[pcIndex], bass + 1)) {
+        acc.push(midi)
+        recurse(pcIndex + 1, acc)
+        acc.pop()
+      }
+    }
+    recurse(0, [])
+  }
+  return [...sets.values()]
+}
+
+// Candidate fingerings for one chord, in tiers of decreasing faithfulness.
+function candidatesForChord(midiNotes: number[]): Candidate[] {
+  const octaveUp = midiNotes.map(n => n + 12)
+  const inRange = (notes: number[]) =>
+    notes.every(n => n >= LOWEST_NOTE && n <= HIGHEST_NOTE)
+
+  const tiers: Array<() => Candidate[]> = [
+    () => findCandidates(midiNotes, 4),
+    () =>
+      inRange(octaveUp)
+        ? withPenalty(findCandidates(octaveUp, 4), OCTAVE_SHIFT_PENALTY)
+        : [],
+    () =>
+      withPenalty(
+        revoicedPitchSets(midiNotes).flatMap(set => findCandidates(set, 4)),
+        REVOICE_PENALTY
+      ),
+    // Last resort: allow an uncomfortable stretch before giving up
+    () => findCandidates(midiNotes, 5),
+    () =>
+      withPenalty(
+        revoicedPitchSets(midiNotes).flatMap(set => findCandidates(set, 5)),
+        REVOICE_PENALTY
+      ),
+  ]
+
+  for (const tier of tiers) {
+    const found = tier()
+    if (found.length) {
+      // Keep the DP small: only the most playable shapes matter
+      return found.sort((a, b) => a.cost - b.cost).slice(0, 24)
+    }
+  }
+  return []
+}
+
+// Assign a fingering to every chord in the sequence, minimizing total
+// shape difficulty plus hand movement (Viterbi over per-chord candidates).
+// Chords with no playable assignment at all (which should only happen for
+// degenerate input, e.g. more notes than strings) get null.
+export function generateTabSequence(
+  chords: number[][]
+): (TabFingering | null)[] {
+  const candidatesPerChord = chords.map(candidatesForChord)
+
+  // Viterbi forward pass
+  const totals: number[][] = []
+  const backPointers: number[][] = []
+  let prevCandidates: Candidate[] = []
+  let prevTotals: number[] = []
+
+  candidatesPerChord.forEach(candidates => {
+    const totalRow: number[] = []
+    const backRow: number[] = []
+
+    candidates.forEach(candidate => {
+      if (!prevCandidates.length) {
+        totalRow.push(candidate.cost)
+        backRow.push(-1)
+        return
+      }
+      let best = Infinity
+      let bestPrev = -1
+      prevCandidates.forEach((prev, j) => {
+        const total =
+          prevTotals[j] +
+          candidate.cost +
+          transitionCost(prev.frets, candidate.frets)
+        if (total < best) {
+          best = total
+          bestPrev = j
+        }
+      })
+      totalRow.push(best)
+      backRow.push(bestPrev)
+    })
+
+    totals.push(totalRow)
+    backPointers.push(backRow)
+    // Chords with no candidates are skipped: the hand-position chain
+    // continues across them from the last playable chord.
+    if (candidates.length) {
+      prevCandidates = candidates
+      prevTotals = totalRow
+    }
+  })
+
+  // Backtrack from the cheapest final state
+  const result: (TabFingering | null)[] = chords.map(() => null)
+  let nextChoice = -1
+  for (let i = chords.length - 1; i >= 0; i--) {
+    const candidates = candidatesPerChord[i]
+    if (!candidates.length) continue
+    let choice: number
+    if (nextChoice === -1) {
+      let best = Infinity
+      choice = 0
+      totals[i].forEach((t, j) => {
+        if (t < best) {
+          best = t
+          choice = j
+        }
+      })
+    } else {
+      choice = nextChoice
+    }
+    result[i] = toFingering(candidates[choice])
+    nextChoice = backPointers[i][choice]
+  }
+
+  return result
+}

--- a/src/features/playback/DisplayControls.tsx
+++ b/src/features/playback/DisplayControls.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-export type DisplayOption = 'keyboard' | 'notation' | 'both'
+export type DisplayOption = 'keyboard' | 'notation' | 'tablature'
 
 interface DisplayControlsProps {
   activeDisplay: DisplayOption
@@ -13,40 +13,46 @@ export const DisplayControls: React.FC<DisplayControlsProps> = ({
   onChange,
   isEditing = false,
 }) => {
-  const handleNotationClick = () => {
-    if (!isEditing) {
-      onChange('notation')
-    }
-  }
+  // Keyboard is always available; the score-like views are disabled while
+  // editing (the app forces the keyboard view during edits).
+  const options: Array<{
+    value: DisplayOption
+    label: string
+    disabledWhileEditing: boolean
+  }> = [
+    { value: 'keyboard', label: 'Keyboard', disabledWhileEditing: false },
+    { value: 'notation', label: 'Notation', disabledWhileEditing: true },
+    { value: 'tablature', label: 'Tab', disabledWhileEditing: true },
+  ]
 
   return (
     <div className="flex gap-2 justify-center">
-      <button
-        onClick={() => onChange('keyboard')}
-        className={`py-1.5 px-3 rounded-md text-sm font-medium transition-colors outline-none ${
-          activeDisplay === 'keyboard'
-            ? 'bg-[#A4B494] text-[#2C1810] hover:bg-[#A4B494] focus:bg-[#A4B494] cursor-pointer'
-            : 'bg-[#F5E6D3] text-[#2C1810] hover:bg-[#A4B494]/50 focus:bg-[#A4B494]/50 cursor-pointer'
-        }`}
-      >
-        Keyboard
-      </button>
-      <button
-        onClick={handleNotationClick}
-        disabled={isEditing}
-        aria-disabled={isEditing}
-        className={`py-1.5 px-3 rounded-md text-sm font-medium transition-colors outline-none ${
-          activeDisplay === 'notation' && !isEditing
-            ? 'bg-[#A4B494] text-[#2C1810] hover:bg-[#A4B494] focus:bg-[#A4B494] cursor-pointer'
-            : 'bg-[#F5E6D3] text-[#2C1810] hover:bg-[#A4B494]/50 focus:bg-[#A4B494]/50 cursor-pointer'
-        } ${
-          isEditing
-            ? 'opacity-50 cursor-not-allowed pointer-events-none'
-            : 'hover:bg-[#A4B494] focus:bg-[#A4B494] cursor-pointer'
-        }`}
-      >
-        Notation
-      </button>
+      {options.map(({ value, label, disabledWhileEditing }) => {
+        const disabled = disabledWhileEditing && isEditing
+        return (
+          <button
+            key={value}
+            onClick={() => {
+              if (!disabled) {
+                onChange(value)
+              }
+            }}
+            disabled={disabled}
+            aria-disabled={disabled}
+            className={`py-1.5 px-3 rounded-md text-sm font-medium transition-colors outline-none ${
+              activeDisplay === value && !disabled
+                ? 'bg-[#A4B494] text-[#2C1810] hover:bg-[#A4B494] focus:bg-[#A4B494] cursor-pointer'
+                : 'bg-[#F5E6D3] text-[#2C1810] hover:bg-[#A4B494]/50 focus:bg-[#A4B494]/50 cursor-pointer'
+            } ${
+              disabled
+                ? 'opacity-50 cursor-not-allowed pointer-events-none'
+                : 'hover:bg-[#A4B494] focus:bg-[#A4B494] cursor-pointer'
+            }`}
+          >
+            {label}
+          </button>
+        )
+      })}
     </div>
   )
 }

--- a/src/features/playback/GuitarTab.tsx
+++ b/src/features/playback/GuitarTab.tsx
@@ -1,0 +1,183 @@
+import React, { useMemo } from 'react'
+import { audioService } from '../../services/audioService'
+import {
+  generateTabSequence,
+  STRING_NAMES,
+  TabFingering,
+} from '../../common/utils/tabUtils'
+
+interface GuitarTabProps {
+  activeNotes: number[]
+  currentChords?: string[]
+}
+
+// Layout constants (SVG user units)
+const WIDTH = 400
+const HEIGHT = 96
+const TOP = 14
+const LINE_GAP = 13
+const LEFT = 30
+const RIGHT = 388
+const CHORDS_PER_ROW = 4
+
+const INK = '#2C1810'
+const PAPER = '#F5E6D3'
+const HIGHLIGHT = '#7A8A6A'
+const MUTED = '#846C5B'
+
+export const GuitarTab: React.FC<GuitarTabProps> = ({
+  activeNotes,
+  currentChords,
+}) => {
+  const sequence = audioService.getCurrentSequence()
+  const position = audioService.getCurrentPosition()
+
+  const fingerings = useMemo(
+    () => generateTabSequence(sequence.map(triad => triad.midiNotes)),
+    // currentChords signals chart edits; the sequence array identity changes
+    // with every regeneration as well.
+    [sequence, currentChords] // eslint-disable-line react-hooks/exhaustive-deps
+  )
+
+  const rowStartIndex = Math.floor(position / CHORDS_PER_ROW) * CHORDS_PER_ROW
+  const rowFingerings = fingerings.slice(
+    rowStartIndex,
+    rowStartIndex + CHORDS_PER_ROW
+  )
+  const highlightIndex =
+    activeNotes.length > 0 ? position - rowStartIndex : -1
+
+  const columnX = (column: number): number =>
+    LEFT + 28 + ((RIGHT - LEFT - 40) / (CHORDS_PER_ROW - 1)) * column
+
+  // String 0 (low E) renders on the bottom line, high e on top
+  const stringY = (stringIndex: number): number =>
+    TOP + (STRING_NAMES.length - 1 - stringIndex) * LINE_GAP
+
+  const renderChord = (
+    fingering: TabFingering | null,
+    column: number
+  ): React.ReactNode => {
+    const x = columnX(column)
+    const isActive = column === highlightIndex
+    const color = isActive ? HIGHLIGHT : INK
+
+    if (!fingering) {
+      return (
+        <text
+          key={`chord-${column}`}
+          x={x}
+          y={stringY(2) + 4}
+          textAnchor="middle"
+          fontSize="10"
+          fill={MUTED}
+        >
+          —
+        </text>
+      )
+    }
+
+    return (
+      <g key={`chord-${column}`}>
+        {fingering.map((fret, stringIndex) => {
+          if (fret === null) return null
+          const y = stringY(stringIndex)
+          const label = String(fret)
+          return (
+            <g key={stringIndex}>
+              {/* mask the string line behind the number */}
+              <rect
+                x={x - label.length * 3.5}
+                y={y - 5}
+                width={label.length * 7}
+                height={10}
+                fill={PAPER}
+              />
+              <text
+                x={x}
+                y={y + 3.5}
+                textAnchor="middle"
+                fontSize="10"
+                fontWeight={isActive ? 700 : 500}
+                fill={color}
+              >
+                {label}
+              </text>
+            </g>
+          )
+        })}
+      </g>
+    )
+  }
+
+  return (
+    <div className="container mx-auto px-4">
+      <div
+        className="relative mx-auto mb-2"
+        style={{
+          height: '100px',
+          maxWidth: '380px',
+        }}
+      >
+        <div className="absolute inset-0 translate-x-[6px] translate-y-[6px] bg-[#2C1810] rounded-lg"></div>
+        <div className="relative w-full h-full bg-[#F5E6D3] rounded-lg p-2">
+          <svg
+            viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
+            className="w-full h-full select-none"
+            role="img"
+            aria-label="Guitar tablature"
+          >
+            {/* string lines */}
+            {STRING_NAMES.map((_, stringIndex) => (
+              <line
+                key={stringIndex}
+                x1={LEFT}
+                y1={stringY(stringIndex)}
+                x2={RIGHT}
+                y2={stringY(stringIndex)}
+                stroke={INK}
+                strokeWidth="0.75"
+              />
+            ))}
+
+            {/* start and end bars */}
+            <line
+              x1={LEFT}
+              y1={stringY(STRING_NAMES.length - 1)}
+              x2={LEFT}
+              y2={stringY(0)}
+              stroke={INK}
+              strokeWidth="1.5"
+            />
+            <line
+              x1={RIGHT}
+              y1={stringY(STRING_NAMES.length - 1)}
+              x2={RIGHT}
+              y2={stringY(0)}
+              stroke={INK}
+              strokeWidth="1.5"
+            />
+
+            {/* string names */}
+            {STRING_NAMES.map((name, stringIndex) => (
+              <text
+                key={name + stringIndex}
+                x={LEFT - 10}
+                y={stringY(stringIndex) + 3.5}
+                textAnchor="middle"
+                fontSize="9"
+                fill={MUTED}
+              >
+                {name}
+              </text>
+            ))}
+
+            {rowFingerings.map((fingering, column) =>
+              renderChord(fingering, column)
+            )}
+          </svg>
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
Adds a **Tab** display option next to Keyboard and Notation that renders the progression as SVG guitar tablature, with the same 4-chord paging and green playback highlight as the notation view.

## Fingering optimization

Any pitch can be played in several places on the fretboard, so fingerings are chosen by optimization rather than naive mapping:

- **Per-chord shape cost** scores playability: fret span (spans over 4 frets are heavily penalized), average fret height (prefers open position), and muted strings between sounded strings (awkward to strum).
- **Dynamic programming across the progression** (Viterbi over per-chord candidates) minimizes total shape cost plus hand movement between consecutive chords — the fretting-hand analogue of the existing voice-leading optimizer. Repeated chords keep identical fingerings and the hand walks between positions instead of jumping.

## Unplayable voicings

Not every keyboard voicing fits on six strings — seventh mode regularly produces close-position clusters low in the range (e.g. Bmaj7 as A#2-B2-D#3-F#3, where four notes that low only fit on three strings). Candidates are generated in tiers of decreasing faithfulness, with penalties so the most faithful playable shape always wins:

1. the exact voicing
2. the exact voicing an octave up (idiomatic — guitar sounds an octave below written pitch)
3. a re-voicing of the same pitch classes keeping the bass pitch class, so the bass line survives
4. the above with a 5-fret stretch as a last resort

## Verification

- 12 new unit tests: pitch fidelity, span limits, open-position preference (C-E-G resolves to the classic open C shape), fingering stability for repeated chords, bounded hand movement, octave-shift and re-voicing fallbacks.
- Verified in the browser across triad and seventh modes: fingerings decoded pitch-by-pitch and confirmed musically correct (e.g. row 1 of Giant Steps: B major at D4-B4-e7 → D major at D4-B3-e5 → G at D5-G7-e7 → Bb at A8-G7-e6, hand flowing through positions 3-6, open strings used where natural). Playback highlight, row paging, and edit-mode disabling all work; no console errors.
- `tsc`, `eslint`, `vite build`, and the full test suite (33 tests) pass.