### PR TITLE
Prefer closed shapes over open strings in guitar tab

### DIFF
--- a/src/common/utils/tabUtils.test.ts
+++ b/src/common/utils/tabUtils.test.ts
@@ -62,10 +62,22 @@ describe('generateTabSequence', () => {
     })
   })
 
-  it('prefers open position for open-friendly chords', () => {
-    // C3 E3 G3 is the middle of the open C shape: A3 D2 G0
+  it('prefers closed (fretted) shapes over open strings', () => {
+    // C3 E3 G3 could sit in open position (A3 D2 G-open), but jazz playing
+    // avoids open strings — the movable shape at E8 A7 D5 should win.
     const [c] = generateTabSequence([[48, 52, 55]])
-    expect(c).toEqual([null, 3, 2, 0, null, null])
+    expect(c).toEqual([8, 7, 5, null, null, null])
+  })
+
+  it('still uses open strings when a chord is otherwise unplayable', () => {
+    // E2 can only be played as the open low E string, so any voicing
+    // containing it must keep that open string.
+    const [fingering] = generateTabSequence([[40, 47, 52]])
+    expect(fingering).not.toBeNull()
+    expect(fingering![0]).toBe(0)
+    expect(soundedNotes(fingering!).sort((a, b) => a - b)).toEqual([
+      40, 47, 52,
+    ])
   })
 
   it('keeps the same fingering for repeated chords', () => {
@@ -138,8 +150,12 @@ describe('generateTabSequence', () => {
     const tabs = generateTabSequence(chords)
     tabs.forEach((fingering, i) => {
       expect(fingering).not.toBeNull()
-      expect(soundedNotes(fingering!).sort((a, b) => a - b)).toEqual(
-        [...chords[i]].sort((a, b) => a - b)
+      // Chords needing open strings may be octave-shifted or re-voiced
+      // into a closed shape, so assert pitch-class fidelity, not octaves
+      const pitchClasses = (notes: number[]) =>
+        [...new Set(notes.map(n => n % 12))].sort((a, b) => a - b)
+      expect(pitchClasses(soundedNotes(fingering!))).toEqual(
+        pitchClasses(chords[i])
       )
       expect(fretSpan(fingering!)).toBeLessThanOrEqual(4)
     })

--- a/src/common/utils/tabUtils.ts
+++ b/src/common/utils/tabUtils.ts
@@ -47,10 +47,21 @@ function shapeCost(strings: number[], frets: number[]): number {
   const innerGaps =
     Math.max(...strings) - Math.min(...strings) + 1 - strings.length
 
-  // Average fret pulls gently toward open position
+  // Open strings are avoided in jazz playing: they break movable shapes
+  // and can't be muted or shifted. Penalized, not banned — if a chord is
+  // only playable with an open string, it still renders.
+  const openStrings = frets.filter(f => f === 0).length
+
+  // Weak tie-break toward the lower half of the neck
   const avgFret = frets.reduce((a, b) => a + b, 0) / frets.length
 
-  return span * 2 + (span >= 4 ? 4 : 0) + innerGaps * 0.75 + avgFret * 0.25
+  return (
+    span * 1.5 +
+    (span >= 4 ? 4 : 0) +
+    innerGaps * 0.75 +
+    openStrings * 4 +
+    avgFret * 0.1
+  )
 }
 
 // Cost of moving the fretting hand between consecutive chords.
@@ -146,40 +157,34 @@ function revoicedPitchSets(midiNotes: number[]): number[][] {
   return [...sets.values()]
 }
 
-// Candidate fingerings for one chord, in tiers of decreasing faithfulness.
+// Candidate fingerings for one chord. All faithfulness tiers compete in a
+// single pool — the exact voicing costs nothing extra, an octave shift or a
+// re-voicing carries a penalty — so a closed re-voiced shape can still beat
+// an exact voicing that is only playable with open strings or an awkward
+// stretch.
 function candidatesForChord(midiNotes: number[]): Candidate[] {
   const octaveUp = midiNotes.map(n => n + 12)
   const inRange = (notes: number[]) =>
     notes.every(n => n >= LOWEST_NOTE && n <= HIGHEST_NOTE)
 
-  const tiers: Array<() => Candidate[]> = [
-    () => findCandidates(midiNotes, 4),
-    () =>
-      inRange(octaveUp)
-        ? withPenalty(findCandidates(octaveUp, 4), OCTAVE_SHIFT_PENALTY)
-        : [],
-    () =>
-      withPenalty(
-        revoicedPitchSets(midiNotes).flatMap(set => findCandidates(set, 4)),
-        REVOICE_PENALTY
+  const poolAtSpan = (maxSpan: number): Candidate[] => [
+    ...findCandidates(midiNotes, maxSpan),
+    ...(inRange(octaveUp)
+      ? withPenalty(findCandidates(octaveUp, maxSpan), OCTAVE_SHIFT_PENALTY)
+      : []),
+    ...withPenalty(
+      revoicedPitchSets(midiNotes).flatMap(set =>
+        findCandidates(set, maxSpan)
       ),
-    // Last resort: allow an uncomfortable stretch before giving up
-    () => findCandidates(midiNotes, 5),
-    () =>
-      withPenalty(
-        revoicedPitchSets(midiNotes).flatMap(set => findCandidates(set, 5)),
-        REVOICE_PENALTY
-      ),
+      REVOICE_PENALTY
+    ),
   ]
 
-  for (const tier of tiers) {
-    const found = tier()
-    if (found.length) {
-      // Keep the DP small: only the most playable shapes matter
-      return found.sort((a, b) => a.cost - b.cost).slice(0, 24)
-    }
-  }
-  return []
+  // Allow an uncomfortable 5-fret stretch only when nothing else exists
+  const pool = poolAtSpan(4)
+  const found = pool.length ? pool : poolAtSpan(5)
+  // Keep the DP small: only the most playable shapes matter
+  return found.sort((a, b) => a.cost - b.cost).slice(0, 24)
 }
 
 // Assign a fingering to every chord in the sequence, minimizing total


### PR DESCRIPTION
Jazz players avoid open strings — they break movable shapes and can't be muted or shifted. This tunes the tab fingering optimizer accordingly:

- **Open strings now carry a strong penalty** (4 per open string). They aren't banned: a chord that is only playable with one — anything containing E2, for instance — still renders with it.
- **The open-position pull is gone**, replaced by a weak low-neck tie-break, and span weight is rebalanced.
- **Faithfulness tiers now compete in one candidate pool** (exact voicing at no penalty, octave-up at +2, re-voicing at +4) instead of a first-non-empty ladder. Previously an exact voicing that was only playable *with* open strings would win outright because its tier was non-empty — e.g. a Gmaj7 voicing with an internal F#-G semitone rendered with two open strings even though a closed re-voicing existed.

Result on Giant Steps: every chord in both triad and seventh mode now renders as a closed movable shape (triads around frets 3-5, sevenths around 5-8, verified via DOM extraction — zero open strings), e.g. Bmaj7 as x-x-4-4-6-6 territory instead of open-position fragments.

Tests updated: the open-position expectation now asserts the movable C shape (E8-A7-D5), plus a new test that open strings still appear when a chord is otherwise unplayable. Full suite 34/34; tsc/eslint clean.