### PR TITLE
Fix tab register: render voicings in written guitar register

### DIFF
--- a/src/common/utils/tabUtils.test.ts
+++ b/src/common/utils/tabUtils.test.ts
@@ -24,7 +24,7 @@ const handPosition = (fingering: TabFingering): number => {
 }
 
 describe('generateTabSequence', () => {
-  it('reproduces every pitch on a distinct string within the fret range', () => {
+  it('preserves each voicing structure, at pitch or an octave up', () => {
     const chords = [
       [48, 52, 55], // C major triad
       [45, 52, 57], // A minor voicing
@@ -36,7 +36,13 @@ describe('generateTabSequence', () => {
     tabs.forEach((fingering, i) => {
       expect(fingering).not.toBeNull()
       const sounded = soundedNotes(fingering!).sort((a, b) => a - b)
-      expect(sounded).toEqual([...chords[i]].sort((a, b) => a - b))
+      const played = [...chords[i]].sort((a, b) => a - b)
+      // Tab renders in written guitar register (an octave above played
+      // pitch) when it fits; either way the voicing structure is intact
+      const matchesPlayed =
+        JSON.stringify(sounded) === JSON.stringify(played) ||
+        JSON.stringify(sounded) === JSON.stringify(played.map(n => n + 12))
+      expect(matchesPlayed).toBe(true)
       fingering!.forEach(fret => {
         if (fret !== null) {
           expect(fret).toBeGreaterThanOrEqual(0)
@@ -64,20 +70,36 @@ describe('generateTabSequence', () => {
 
   it('prefers closed (fretted) shapes over open strings', () => {
     // C3 E3 G3 could sit in open position (A3 D2 G-open), but jazz playing
-    // avoids open strings — the movable shape at E8 A7 D5 should win.
+    // avoids open strings — a fretted movable shape should win.
     const [c] = generateTabSequence([[48, 52, 55]])
-    expect(c).toEqual([8, 7, 5, null, null, null])
+    expect(frettedFrets(c!).length).toBe(3) // no open strings
+    expect(c!.includes(0)).toBe(false)
   })
 
   it('still uses open strings when a chord is otherwise unplayable', () => {
-    // E2 can only be played as the open low E string, so any voicing
-    // containing it must keep that open string.
-    const [fingering] = generateTabSequence([[40, 47, 52]])
+    // E2 only exists as the open low E string, and the high G#4 keeps the
+    // chord from shifting up an octave — the open string must stay.
+    const [fingering] = generateTabSequence([[40, 47, 68]])
     expect(fingering).not.toBeNull()
     expect(fingering![0]).toBe(0)
     expect(soundedNotes(fingering!).sort((a, b) => a - b)).toEqual([
-      40, 47, 52,
+      40, 47, 68,
     ])
+  })
+
+  it('renders the played voicing structure an octave up (guitar register)', () => {
+    // The opening of Giant Steps as the app voices it: true open triads in
+    // a low keyboard register. On guitar these render an octave up with the
+    // exact voicing structure intact — never collapsed into closed shapes.
+    const tabs = generateTabSequence([
+      [42, 51, 59], // Bmaj7 triad: F#2 D#3 B3
+      [42, 50, 57], // D7 triad: F#2 D3 A3
+      [43, 50, 59], // Gmaj7 triad: G2 D3 B3
+    ])
+    expect(tabs[0]).toEqual([null, null, 4, null, 4, 7])
+    expect(tabs[2]).toEqual([null, null, 5, 7, null, 7])
+    // The middle chord keeps the same register (structure +12, elementwise)
+    expect(soundedNotes(tabs[1]!).sort((a, b) => a - b)).toEqual([54, 62, 69])
   })
 
   it('keeps the same fingering for repeated chords', () => {

--- a/src/common/utils/tabUtils.ts
+++ b/src/common/utils/tabUtils.ts
@@ -7,12 +7,19 @@
 // fingerings that minimizes shape cost plus hand movement between chords —
 // the fretting-hand analogue of the voice-leading optimizer.
 //
-// Not every keyboard voicing is playable on six strings (close-position
-// clusters low on the neck, for instance), so candidates are generated in
-// tiers of decreasing faithfulness: the exact voicing, the voicing an octave
-// up (guitar sounds an octave below written pitch, so this is idiomatic),
-// and finally a re-voicing of the same pitch classes over the same bass.
-// Later tiers carry penalties so the most faithful playable shape wins.
+// Guitar is written an octave above sounding pitch, and the app's voicings
+// sit in a low keyboard register — so the default is to render each voicing
+// an octave up, the guitar's natural chord register. Chords too high to
+// shift fall back to their played pitch. Each candidate carries its
+// register displacement, and transitions penalize CHANGING displacement
+// between chords, so whole stretches of the chart sit in one register
+// instead of lurching octave to octave chord by chord.
+//
+// Not every voicing is playable on six strings (close-position clusters,
+// for instance), so as a last resort a chord is re-voiced: same pitch
+// classes over the same bass, at or above the original register. The
+// re-voice penalty is high enough that a playable structure-preserving
+// shape always wins.
 
 // Standard tuning, low to high: E2 A2 D3 G3 B3 E4
 export const STANDARD_TUNING = [40, 45, 50, 55, 59, 64]
@@ -21,8 +28,17 @@ const MAX_FRET = 15
 const LOWEST_NOTE = STANDARD_TUNING[0]
 const HIGHEST_NOTE = STANDARD_TUNING[STANDARD_TUNING.length - 1] + MAX_FRET
 
-const OCTAVE_SHIFT_PENALTY = 2
-const REVOICE_PENALTY = 4
+// Where the fretting hand feels most at home for chord work
+const HOME_FRET = 5
+
+// Mild: staying at played pitch (an octave below written guitar register)
+// is the fallback for chords that sit too high to shift up
+const AT_PITCH_PENALTY = 0.5
+// High enough that re-voicing only wins when nothing faithful is playable
+const REVOICE_PENALTY = 8
+// Cost per semitone of register-displacement change between consecutive
+// chords: an unforced octave lurch (12 semitones) costs 4.8
+const DISPLACEMENT_CHANGE_WEIGHT = 0.4
 
 // One chord's fingering: fret number per string (index 0 = low E),
 // or null where the string isn't played.
@@ -52,7 +68,7 @@ function shapeCost(strings: number[], frets: number[]): number {
   // only playable with an open string, it still renders.
   const openStrings = frets.filter(f => f === 0).length
 
-  // Weak tie-break toward the lower half of the neck
+  // Weak tie-break toward the middle of the neck, where chord work sits
   const avgFret = frets.reduce((a, b) => a + b, 0) / frets.length
 
   return (
@@ -60,19 +76,28 @@ function shapeCost(strings: number[], frets: number[]): number {
     (span >= 4 ? 4 : 0) +
     innerGaps * 0.75 +
     openStrings * 4 +
-    avgFret * 0.1
+    Math.abs(avgFret - HOME_FRET) * 0.1
   )
-}
-
-// Cost of moving the fretting hand between consecutive chords.
-function transitionCost(prevFrets: number[], nextFrets: number[]): number {
-  return Math.abs(handPosition(prevFrets) - handPosition(nextFrets))
 }
 
 type Candidate = {
   strings: number[] // string index per note, ascending
   frets: number[] // fret per note, parallel to strings
   cost: number
+  // Semitones between what this candidate sounds and the played voicing
+  // (0 for the exact voicing, 12 an octave up, fractional for re-voicings)
+  displacement: number
+}
+
+// Cost of moving the fretting hand between consecutive chords, plus a
+// penalty for changing register displacement so the tab doesn't jump
+// octaves between neighboring chords unless the chart forces it.
+function transitionCost(prev: Candidate, next: Candidate): number {
+  return (
+    Math.abs(handPosition(prev.frets) - handPosition(next.frets)) +
+    Math.abs(prev.displacement - next.displacement) *
+      DISPLACEMENT_CHANGE_WEIGHT
+  )
 }
 
 // Enumerate every way to place the chord's notes (ascending) on strictly
@@ -93,6 +118,7 @@ function findCandidates(midiNotes: number[], maxSpan: number): Candidate[] {
           strings: [...acc],
           frets,
           cost: shapeCost(acc, frets),
+          displacement: 0,
         })
       }
       return
@@ -118,15 +144,25 @@ function toFingering(candidate: Candidate): TabFingering {
   return fingering
 }
 
-const withPenalty = (candidates: Candidate[], penalty: number): Candidate[] =>
-  candidates.map(c => ({ ...c, cost: c.cost + penalty }))
+const tag = (
+  candidates: Candidate[],
+  penalty: number,
+  displacement: number
+): Candidate[] =>
+  candidates.map(c => ({ ...c, cost: c.cost + penalty, displacement }))
+
+const average = (notes: number[]): number =>
+  notes.reduce((a, b) => a + b, 0) / notes.length
 
 // All ways to place the chord's pitch classes on the fretboard as an
 // ascending set of distinct pitches, keeping the original bass pitch class
-// on the bottom so the arrangement's bass line survives.
+// on the bottom so the arrangement's bass line survives. Re-voicings sit at
+// or slightly above the original register — never below it, so a re-voiced
+// chord can't lurch down an octave relative to its neighbors.
 function revoicedPitchSets(midiNotes: number[]): number[][] {
   const bassPc = midiNotes[0] % 12
   const upperPcs = midiNotes.slice(1).map(n => n % 12)
+  const originalAvg = average(midiNotes)
 
   const optionsForPc = (pc: number, min: number): number[] => {
     const options: number[] = []
@@ -141,7 +177,12 @@ function revoicedPitchSets(midiNotes: number[]): number[][] {
     const recurse = (pcIndex: number, acc: number[]) => {
       if (pcIndex === upperPcs.length) {
         const set = [bass, ...acc].sort((a, b) => a - b)
-        if (new Set(set).size === set.length) {
+        const avg = average(set)
+        if (
+          new Set(set).size === set.length &&
+          avg >= originalAvg &&
+          avg <= originalAvg + 12
+        ) {
           sets.set(set.join(','), set)
         }
         return
@@ -166,17 +207,14 @@ function candidatesForChord(midiNotes: number[]): Candidate[] {
   const octaveUp = midiNotes.map(n => n + 12)
   const inRange = (notes: number[]) =>
     notes.every(n => n >= LOWEST_NOTE && n <= HIGHEST_NOTE)
+  const originalAvg = average(midiNotes)
 
   const poolAtSpan = (maxSpan: number): Candidate[] => [
-    ...findCandidates(midiNotes, maxSpan),
-    ...(inRange(octaveUp)
-      ? withPenalty(findCandidates(octaveUp, maxSpan), OCTAVE_SHIFT_PENALTY)
-      : []),
-    ...withPenalty(
-      revoicedPitchSets(midiNotes).flatMap(set =>
-        findCandidates(set, maxSpan)
-      ),
-      REVOICE_PENALTY
+    // The written-pitch register (an octave up) is the guitar default
+    ...(inRange(octaveUp) ? tag(findCandidates(octaveUp, maxSpan), 0, 12) : []),
+    ...tag(findCandidates(midiNotes, maxSpan), AT_PITCH_PENALTY, 0),
+    ...revoicedPitchSets(midiNotes).flatMap(set =>
+      tag(findCandidates(set, maxSpan), REVOICE_PENALTY, average(set) - originalAvg)
     ),
   ]
 
@@ -187,10 +225,11 @@ function candidatesForChord(midiNotes: number[]): Candidate[] {
   return found.sort((a, b) => a.cost - b.cost).slice(0, 24)
 }
 
-// Assign a fingering to every chord in the sequence, minimizing total
-// shape difficulty plus hand movement (Viterbi over per-chord candidates).
-// Chords with no playable assignment at all (which should only happen for
-// degenerate input, e.g. more notes than strings) get null.
+// Assign a fingering to every chord in the sequence: Viterbi over per-chord
+// candidates, minimizing total shape difficulty plus hand movement and
+// register-displacement changes between chords. Chords with no playable
+// assignment at all (degenerate input, e.g. more notes than strings) get
+// null.
 export function generateTabSequence(
   chords: number[][]
 ): (TabFingering | null)[] {
@@ -216,9 +255,7 @@ export function generateTabSequence(
       let bestPrev = -1
       prevCandidates.forEach((prev, j) => {
         const total =
-          prevTotals[j] +
-          candidate.cost +
-          transitionCost(prev.frets, candidate.frets)
+          prevTotals[j] + candidate.cost + transitionCost(prev, candidate)
         if (total < best) {
           best = total
           bestPrev = j


### PR DESCRIPTION
Fixes the register inconsistencies reported in the tab display: in open-triad mode, Bmaj7's true open triad (F#2-D#3-B3) rendered as the collapsed closed shape x-x-4-4-4-x instead of x-x-4-x-4-7, and Gmaj7 rendered an octave below its neighbors.

## Root cause

Octave decisions were made per chord, and the re-voice fallback could beat a playable exact voicing on shape cost alone — so one row of the chart mixed three register treatments (octave-up, at-pitch, structure-collapsing re-voice).

## Changes

- **Written guitar register is the default.** Guitar is notated an octave above sounding pitch, and the app's voicings sit low — so each voicing now renders an octave up by default, preserving its exact structure. Played pitch is the fallback for chords too high to shift (a global shift isn't possible: Giant Steps' played voicings reach D#5, which is off the fretboard at +12).
- **Register displacement is part of the optimization state.** Every candidate carries its displacement from the played pitch, and transitions penalize *changing* displacement, so whole stretches of the chart sit in one register and only move when the chart's range forces it. On Giant Steps this yields exactly one register transition across 32 chords, at the point where the played voicings climb.
- **Re-voicing is now a true last resort**: penalty raised so it can never beat a playable structure-preserving shape, and re-voicings are constrained to sit at or above the original register (no more octave-down lurches).
- The low-neck tie-break became distance-from-home-fret (5), so mid-neck shapes aren't penalized.

## Result on Giant Steps (open triads)

| Chord | Played | Before | After |
|---|---|---|---|
| Bmaj7 | F#2 D#3 B3 | x-x-4-4-4-x (collapsed) | **x-x-4-x-4-7** (exact structure, +12) |
| Gmaj7 | G2 D3 B3 | 3-5-x-4-x-x (octave below neighbors) | **x-x-5-7-x-7** (exact structure, +12) |

Full chart: zero open strings, zero re-voicings, one register transition. Seventh mode: zero open strings, re-voicings only for genuine keyboard clusters.

Tests updated for the written-register semantics plus a regression test pinning the reported chords; 35/35 pass, tsc/eslint clean, verified in the browser.