### PR TITLE
Fretboard view with scale degrees, larger tab numerals, slash chords

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -9,6 +9,7 @@ import { audioService } from '../services/audioService'
 import { InfoModal } from '../features/info/InfoModal'
 import { SheetMusic } from '../features/playback/SheetMusic'
 import { GuitarTab } from '../features/playback/GuitarTab'
+import { Fretboard } from '../features/playback/Fretboard'
 import {
   DisplayControls,
   DisplayOption,
@@ -82,6 +83,21 @@ function ChartRoute() {
         >
           <div className="flex justify-center">
             <GuitarTab
+              activeNotes={activeNotes}
+              currentChords={currentChords}
+            />
+          </div>
+        </div>
+
+        <div
+          className={`absolute w-full transition-opacity duration-200 ${
+            activeDisplay === 'fretboard' && !isEditing
+              ? 'opacity-100'
+              : 'opacity-0 pointer-events-none'
+          }`}
+        >
+          <div className="flex justify-center">
+            <Fretboard
               activeNotes={activeNotes}
               currentChords={currentChords}
             />

--- a/src/common/utils/chordLabels.test.ts
+++ b/src/common/utils/chordLabels.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest'
+import {
+  formatChordWithBass,
+  getScaleDegreeLabel,
+  noteNameForMidi,
+} from './chordUtils'
+
+describe('formatChordWithBass', () => {
+  it('adds a slash bass when the bass is not the root', () => {
+    // F major with an A in the bass (A2 = 45)
+    expect(formatChordWithBass('F', 45)).toBe('F/A')
+    // Bmaj7 with the fifth in the bass (F#3 = 54)
+    expect(formatChordWithBass('Bmaj7', 54)).toBe('Bmaj7/F#')
+    // Bb7 with the third in the bass (D3 = 50)
+    expect(formatChordWithBass('Bb7', 50)).toBe('Bb7/D')
+  })
+
+  it('keeps the plain symbol when the bass is the root, any octave', () => {
+    expect(formatChordWithBass('F', 41)).toBe('F')
+    expect(formatChordWithBass('F', 53)).toBe('F')
+    expect(formatChordWithBass('Bmaj7', 47)).toBe('Bmaj7')
+  })
+
+  it('spells the bass to match the chord root accidental', () => {
+    // Flat-side chord: Eb over Bb7... bass Ab (56) under Bb7 -> Ab, not G#
+    expect(formatChordWithBass('Bb7', 56)).toBe('Bb7/Ab')
+    // Sharp-side chord: D#3 (51) under Bmaj7 -> D#, not Eb
+    expect(formatChordWithBass('Bmaj7', 51)).toBe('Bmaj7/D#')
+  })
+})
+
+describe('getScaleDegreeLabel', () => {
+  it('labels chord tones relative to the chord root', () => {
+    // B major: F# is the 5th, D# the 3rd, A# the 7th
+    expect(getScaleDegreeLabel(47, 'Bmaj7')).toBe('R')
+    expect(getScaleDegreeLabel(54, 'Bmaj7')).toBe('5')
+    expect(getScaleDegreeLabel(51, 'Bmaj7')).toBe('3')
+    expect(getScaleDegreeLabel(58, 'Bmaj7')).toBe('7')
+  })
+
+  it('labels flat degrees for minor and dominant chords', () => {
+    // D minor: F is the b3
+    expect(getScaleDegreeLabel(53, 'Dm7')).toBe('b3')
+    // G7: F is the b7
+    expect(getScaleDegreeLabel(53, 'G7')).toBe('b7')
+    // C7: Gb is the b5
+    expect(getScaleDegreeLabel(54, 'C7b5')).toBe('b5')
+  })
+
+  it('is octave-independent', () => {
+    expect(getScaleDegreeLabel(41, 'F')).toBe('R')
+    expect(getScaleDegreeLabel(65, 'F')).toBe('R')
+    expect(getScaleDegreeLabel(69, 'F')).toBe('3')
+  })
+})
+
+describe('noteNameForMidi', () => {
+  it('uses flats for flat-side chords and sharps otherwise', () => {
+    expect(noteNameForMidi(51, 'Eb')).toBe('Eb')
+    expect(noteNameForMidi(51, 'B')).toBe('D#')
+    expect(noteNameForMidi(56, 'F')).toBe('Ab')
+  })
+})

--- a/src/common/utils/chordUtils.ts
+++ b/src/common/utils/chordUtils.ts
@@ -94,6 +94,37 @@ function sum(arr: number[]): number {
   return arr.reduce((a, b) => a + b, 0)
 }
 
+const SHARP_NAMES = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B']
+const FLAT_NAMES = ['C', 'Db', 'D', 'Eb', 'E', 'F', 'Gb', 'G', 'Ab', 'A', 'Bb', 'B']
+
+// Spell a pitch in the context of a chord: flat-side roots get flat
+// spellings (Bb7 -> Ab, not G#), everything else gets sharps.
+export function noteNameForMidi(midi: number, chordRoot: string): string {
+  const useFlats = chordRoot.includes('b') || chordRoot === 'F'
+  return (useFlats ? FLAT_NAMES : SHARP_NAMES)[((midi % 12) + 12) % 12]
+}
+
+// Jazz-style degree name for each semitone offset from the root
+export const DEGREE_LABELS = [
+  'R', 'b9', '9', 'b3', '3', '11', 'b5', '5', '#5', '13', 'b7', '7',
+]
+
+export function getScaleDegreeLabel(midi: number, chord: string): string {
+  const { standardizedRoot } = parseChord(chord)
+  const rootMidi = NOTE_TO_MIDI_BASE[standardizedRoot]
+  return DEGREE_LABELS[(((midi - rootMidi) % 12) + 12) % 12]
+}
+
+// "F" with an A in the bass -> "F/A"; bass on the root stays plain "F"
+export function formatChordWithBass(chord: string, bassMidi: number): string {
+  const { originalRoot, standardizedRoot } = parseChord(chord)
+  const rootMidi = NOTE_TO_MIDI_BASE[standardizedRoot]
+  if ((((bassMidi - rootMidi) % 12) + 12) % 12 === 0) {
+    return chord
+  }
+  return `${chord}/${noteNameForMidi(bassMidi, originalRoot)}`
+}
+
 function generatePermutations(notes: string[]): string[] {
   const result: string[] = []
   const n = notes.length

--- a/src/features/playback/DisplayControls.tsx
+++ b/src/features/playback/DisplayControls.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-export type DisplayOption = 'keyboard' | 'notation' | 'tablature'
+export type DisplayOption = 'keyboard' | 'notation' | 'tablature' | 'fretboard'
 
 interface DisplayControlsProps {
   activeDisplay: DisplayOption
@@ -23,6 +23,7 @@ export const DisplayControls: React.FC<DisplayControlsProps> = ({
     { value: 'keyboard', label: 'Keyboard', disabledWhileEditing: false },
     { value: 'notation', label: 'Notation', disabledWhileEditing: true },
     { value: 'tablature', label: 'Tab', disabledWhileEditing: true },
+    { value: 'fretboard', label: 'Fretboard', disabledWhileEditing: true },
   ]
 
   return (

--- a/src/features/playback/Fretboard.tsx
+++ b/src/features/playback/Fretboard.tsx
@@ -1,0 +1,204 @@
+import React, { useMemo } from 'react'
+import { audioService } from '../../services/audioService'
+import {
+  generateTabSequence,
+  STANDARD_TUNING,
+  STRING_NAMES,
+} from '../../common/utils/tabUtils'
+import { getScaleDegreeLabel } from '../../common/utils/chordUtils'
+
+interface FretboardProps {
+  activeNotes: number[]
+  currentChords?: string[]
+}
+
+// Layout constants (SVG user units)
+const WIDTH = 760
+const HEIGHT = 112
+const FRETS = 15
+const NUT_X = 40
+const BOARD_RIGHT = 748
+const FRET_W = (BOARD_RIGHT - NUT_X) / FRETS
+const TOP = 14
+const STRING_GAP = 16
+const MARKER_FRETS = [3, 5, 7, 9, 15]
+const NOTE_RADIUS = 7.5
+
+const INK = '#2C1810'
+const PAPER = '#F5E6D3'
+const HIGHLIGHT = '#7A8A6A'
+const MUTED = '#846C5B'
+
+export const Fretboard: React.FC<FretboardProps> = ({
+  activeNotes,
+  currentChords,
+}) => {
+  const sequence = audioService.getCurrentSequence()
+  const position = audioService.getCurrentPosition()
+
+  const fingerings = useMemo(
+    () => generateTabSequence(sequence.map(triad => triad.midiNotes)),
+    // currentChords signals chart edits; the sequence array identity changes
+    // with every regeneration as well.
+    [sequence, currentChords] // eslint-disable-line react-hooks/exhaustive-deps
+  )
+
+  const fingering = activeNotes.length > 0 ? (fingerings[position] ?? null) : null
+  const chordName = sequence[position]?.chordName ?? ''
+
+  // String 0 (low E) renders on the bottom line, high e on top
+  const stringY = (stringIndex: number): number =>
+    TOP + (STRING_NAMES.length - 1 - stringIndex) * STRING_GAP
+  // Notes sit between fret wires; open strings sit just left of the nut
+  const noteX = (fret: number): number =>
+    fret === 0 ? NUT_X - 14 : NUT_X + (fret - 0.5) * FRET_W
+
+  const midY = (stringY(0) + stringY(STRING_NAMES.length - 1)) / 2
+
+  return (
+    <div className="container mx-auto px-4">
+      <div
+        className="relative mx-auto mb-2"
+        style={{
+          height: '120px',
+          maxWidth: '780px',
+        }}
+      >
+        <div className="absolute inset-0 translate-x-[6px] translate-y-[6px] bg-[#2C1810] rounded-lg"></div>
+        <div className="relative w-full h-full bg-[#F5E6D3] rounded-lg p-2">
+          <svg
+            viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
+            className="w-full h-full select-none"
+            role="img"
+            aria-label="Guitar fretboard"
+          >
+            {/* nut */}
+            <line
+              x1={NUT_X}
+              y1={stringY(STRING_NAMES.length - 1)}
+              x2={NUT_X}
+              y2={stringY(0)}
+              stroke={INK}
+              strokeWidth="3.5"
+            />
+
+            {/* fret wires */}
+            {Array.from({ length: FRETS }, (_, i) => i + 1).map(fret => (
+              <line
+                key={fret}
+                x1={NUT_X + fret * FRET_W}
+                y1={stringY(STRING_NAMES.length - 1)}
+                x2={NUT_X + fret * FRET_W}
+                y2={stringY(0)}
+                stroke={INK}
+                strokeWidth="1"
+                opacity="0.35"
+              />
+            ))}
+
+            {/* position markers */}
+            {MARKER_FRETS.map(fret => (
+              <circle
+                key={fret}
+                cx={noteX(fret)}
+                cy={midY}
+                r="4"
+                fill={MUTED}
+                opacity="0.25"
+              />
+            ))}
+            <circle
+              cx={noteX(12)}
+              cy={midY - STRING_GAP}
+              r="4"
+              fill={MUTED}
+              opacity="0.25"
+            />
+            <circle
+              cx={noteX(12)}
+              cy={midY + STRING_GAP}
+              r="4"
+              fill={MUTED}
+              opacity="0.25"
+            />
+
+            {/* strings, thicker toward the low E */}
+            {STRING_NAMES.map((_, stringIndex) => (
+              <line
+                key={stringIndex}
+                x1={NUT_X}
+                y1={stringY(stringIndex)}
+                x2={BOARD_RIGHT}
+                y2={stringY(stringIndex)}
+                stroke={INK}
+                strokeWidth={1.6 - stringIndex * 0.16}
+              />
+            ))}
+
+            {/* string names */}
+            {STRING_NAMES.map((name, stringIndex) => (
+              <text
+                key={name + stringIndex}
+                x={12}
+                y={stringY(stringIndex) + 3.5}
+                textAnchor="middle"
+                fontSize="10"
+                fill={MUTED}
+              >
+                {name}
+              </text>
+            ))}
+
+            {/* fret numbers */}
+            {[...MARKER_FRETS, 12].map(fret => (
+              <text
+                key={fret}
+                x={noteX(fret)}
+                y={HEIGHT - 3}
+                textAnchor="middle"
+                fontSize="9"
+                fill={MUTED}
+              >
+                {fret}
+              </text>
+            ))}
+
+            {/* played notes, labeled by scale degree relative to the root */}
+            {fingering?.map((fret, stringIndex) => {
+              if (fret === null) return null
+              const midi = STANDARD_TUNING[stringIndex] + fret
+              const degree = chordName
+                ? getScaleDegreeLabel(midi, chordName)
+                : ''
+              const isRoot = degree === 'R'
+              const x = noteX(fret)
+              const y = stringY(stringIndex)
+              return (
+                <g key={stringIndex}>
+                  <circle
+                    cx={x}
+                    cy={y}
+                    r={NOTE_RADIUS}
+                    fill={isRoot ? INK : HIGHLIGHT}
+                    stroke={INK}
+                    strokeWidth={isRoot ? 0 : 1}
+                  />
+                  <text
+                    x={x}
+                    y={y + 3}
+                    textAnchor="middle"
+                    fontSize={degree.length > 1 ? 8 : 9}
+                    fontWeight={700}
+                    fill={PAPER}
+                  >
+                    {degree}
+                  </text>
+                </g>
+              )
+            })}
+          </svg>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/features/playback/GuitarTab.tsx
+++ b/src/features/playback/GuitarTab.tsx
@@ -2,9 +2,11 @@ import React, { useMemo } from 'react'
 import { audioService } from '../../services/audioService'
 import {
   generateTabSequence,
+  STANDARD_TUNING,
   STRING_NAMES,
   TabFingering,
 } from '../../common/utils/tabUtils'
+import { formatChordWithBass } from '../../common/utils/chordUtils'
 
 interface GuitarTabProps {
   activeNotes: number[]
@@ -13,10 +15,10 @@ interface GuitarTabProps {
 
 // Layout constants (SVG user units)
 const WIDTH = 400
-const HEIGHT = 108
-const LABEL_Y = 11
-const TOP = 26
-const LINE_GAP = 13
+const HEIGHT = 114
+const LABEL_Y = 12
+const TOP = 30
+const LINE_GAP = 15
 const LEFT = 30
 const RIGHT = 388
 const CHORDS_PER_ROW = 4
@@ -47,10 +49,17 @@ export const GuitarTab: React.FC<GuitarTabProps> = ({
   )
   const rowChordNames = sequence
     .slice(rowStartIndex, rowStartIndex + CHORDS_PER_ROW)
-    .map(
-      (triad, column) =>
+    .map((triad, column) => {
+      const name =
         triad.chordName || currentChords?.[rowStartIndex + column] || ''
-    )
+      if (!name) return ''
+      // Label inversions with their bass note (F with A in the bass -> F/A)
+      const fingering = rowFingerings[column]
+      const bassString = fingering?.findIndex(fret => fret !== null) ?? -1
+      if (bassString === -1) return name
+      const bassMidi = STANDARD_TUNING[bassString] + fingering![bassString]!
+      return formatChordWithBass(name, bassMidi)
+    })
   const highlightIndex =
     activeNotes.length > 0 ? position - rowStartIndex : -1
 
@@ -76,7 +85,7 @@ export const GuitarTab: React.FC<GuitarTabProps> = ({
           x={x}
           y={stringY(2) + 4}
           textAnchor="middle"
-          fontSize="10"
+          fontSize="12"
           fill={MUTED}
         >
           —
@@ -94,17 +103,17 @@ export const GuitarTab: React.FC<GuitarTabProps> = ({
             <g key={stringIndex}>
               {/* mask the string line behind the number */}
               <rect
-                x={x - label.length * 3.5}
-                y={y - 5}
-                width={label.length * 7}
-                height={10}
+                x={x - label.length * 4.25}
+                y={y - 6.5}
+                width={label.length * 8.5}
+                height={13}
                 fill={PAPER}
               />
               <text
                 x={x}
-                y={y + 3.5}
+                y={y + 4.5}
                 textAnchor="middle"
-                fontSize="10"
+                fontSize="13"
                 fontWeight={isActive ? 700 : 500}
                 fill={color}
               >
@@ -122,8 +131,8 @@ export const GuitarTab: React.FC<GuitarTabProps> = ({
       <div
         className="relative mx-auto mb-2"
         style={{
-          height: '100px',
-          maxWidth: '380px',
+          height: '120px',
+          maxWidth: '420px',
         }}
       >
         <div className="absolute inset-0 translate-x-[6px] translate-y-[6px] bg-[#2C1810] rounded-lg"></div>
@@ -169,10 +178,10 @@ export const GuitarTab: React.FC<GuitarTabProps> = ({
             {STRING_NAMES.map((name, stringIndex) => (
               <text
                 key={name + stringIndex}
-                x={LEFT - 10}
+                x={LEFT - 11}
                 y={stringY(stringIndex) + 3.5}
                 textAnchor="middle"
-                fontSize="9"
+                fontSize="10"
                 fill={MUTED}
               >
                 {name}
@@ -187,7 +196,7 @@ export const GuitarTab: React.FC<GuitarTabProps> = ({
                   x={columnX(column)}
                   y={LABEL_Y}
                   textAnchor="middle"
-                  fontSize="10"
+                  fontSize="11"
                   fontWeight={column === highlightIndex ? 700 : 600}
                   fill={column === highlightIndex ? HIGHLIGHT : INK}
                 >


### PR DESCRIPTION
Three display improvements from design review:

## Larger tab numerals
The fret numbers rendered at ~9px effective after SVG scaling. They're now 13 in a taller, slightly wider card with more line spacing — the numbers are the payload of a tab and read clearly now.

## Slash-chord labels
Tab columns now label inversions with their bass note: `Bmaj7/F#`, `Bb7/F`, plain `Gmaj7` when the bass is the root. In this app the bass line is chosen by the voice-leading optimizer, so the inversion is meaningful information. Bass spelling follows the chord root's accidental side (`Bmaj7/A#` sharp-side, `Bb7/Ab` flat-side). Covered by new unit tests.

## Fretboard view
A fourth display option that plots the current chord's fingering on a 15-fret fretboard diagram — nut, fret wires, position markers (double at 12), gauge-graded strings, fret numbers. Each sounded note is a circle labeled with its scale degree relative to the chord root (R, 3, b3, 5, b7, 9, …), root filled dark. It follows playback and chord selection exactly like the keyboard view, and reflects the tab's actual fingering positions.

## Verification
- New `chordLabels.test.ts` covers slash formatting, degree labels (b3/b7/b5 for minor/dominant/altered), octave independence, and enharmonic spelling. Suite: 42/42, tsc/eslint clean.
- Browser-verified: triad mode shows R/3/5 markers following chord clicks; seventh-mode D7 plots R/3/5/b7 (confirmed via DOM); slash labels correct in both modes; no console errors.