### PR TITLE
Hide guitar tab and fretboard views behind a feature flag

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -5,6 +5,7 @@ import { PlaybackControls } from '../features/playback/PlaybackControls'
 import { InstrumentSelector } from '../features/playback/InstrumentSelector'
 import { useParams, useNavigate } from 'react-router-dom'
 import { decodeChartData } from '../common/utils/urlUtils'
+import { SHOW_GUITAR_VIEWS } from '../common/config'
 import { audioService } from '../services/audioService'
 import { InfoModal } from '../features/info/InfoModal'
 import { SheetMusic } from '../features/playback/SheetMusic'
@@ -74,35 +75,39 @@ function ChartRoute() {
           </div>
         </div>
 
-        <div
-          className={`absolute w-full transition-opacity duration-200 ${
-            activeDisplay === 'tablature' && !isEditing
-              ? 'opacity-100'
-              : 'opacity-0 pointer-events-none'
-          }`}
-        >
-          <div className="flex justify-center">
-            <GuitarTab
-              activeNotes={activeNotes}
-              currentChords={currentChords}
-            />
-          </div>
-        </div>
+        {SHOW_GUITAR_VIEWS && (
+          <>
+            <div
+              className={`absolute w-full transition-opacity duration-200 ${
+                activeDisplay === 'tablature' && !isEditing
+                  ? 'opacity-100'
+                  : 'opacity-0 pointer-events-none'
+              }`}
+            >
+              <div className="flex justify-center">
+                <GuitarTab
+                  activeNotes={activeNotes}
+                  currentChords={currentChords}
+                />
+              </div>
+            </div>
 
-        <div
-          className={`absolute w-full transition-opacity duration-200 ${
-            activeDisplay === 'fretboard' && !isEditing
-              ? 'opacity-100'
-              : 'opacity-0 pointer-events-none'
-          }`}
-        >
-          <div className="flex justify-center">
-            <Fretboard
-              activeNotes={activeNotes}
-              currentChords={currentChords}
-            />
-          </div>
-        </div>
+            <div
+              className={`absolute w-full transition-opacity duration-200 ${
+                activeDisplay === 'fretboard' && !isEditing
+                  ? 'opacity-100'
+                  : 'opacity-0 pointer-events-none'
+              }`}
+            >
+              <div className="flex justify-center">
+                <Fretboard
+                  activeNotes={activeNotes}
+                  currentChords={currentChords}
+                />
+              </div>
+            </div>
+          </>
+        )}
 
         {/* Invisible div to maintain height */}
         <div className="invisible">

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -1,0 +1,8 @@
+// Feature flags
+
+// Guitar tab + fretboard views are hidden while known issues are resolved:
+// the fretboard card overlaps the controls panel, and the tab/fretboard
+// fingerings can fall out of sync with the generated voicings shown on the
+// keyboard (the fingering optimizer octave-shifts or re-voices chords that
+// are unplayable as generated). Flip to true to work on them locally.
+export const SHOW_GUITAR_VIEWS = false

--- a/src/features/playback/DisplayControls.tsx
+++ b/src/features/playback/DisplayControls.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { SHOW_GUITAR_VIEWS } from '../../common/config'
 
 export type DisplayOption = 'keyboard' | 'notation' | 'tablature' | 'fretboard'
 
@@ -22,8 +23,12 @@ export const DisplayControls: React.FC<DisplayControlsProps> = ({
   }> = [
     { value: 'keyboard', label: 'Keyboard', disabledWhileEditing: false },
     { value: 'notation', label: 'Notation', disabledWhileEditing: true },
-    { value: 'tablature', label: 'Tab', disabledWhileEditing: true },
-    { value: 'fretboard', label: 'Fretboard', disabledWhileEditing: true },
+    ...(SHOW_GUITAR_VIEWS
+      ? ([
+          { value: 'tablature', label: 'Tab', disabledWhileEditing: true },
+          { value: 'fretboard', label: 'Fretboard', disabledWhileEditing: true },
+        ] as const)
+      : []),
   ]
 
   return (


### PR DESCRIPTION
The tab/fretboard views are deployed but have known issues, so this hides them from users while we fix them. `SHOW_GUITAR_VIEWS` in `src/common/config.ts` defaults to `false`: the Tab and Fretboard buttons disappear and their panes don't render. Flip to `true` to work on them locally.

Issues to resolve before re-enabling (tracked in the config comment):
1. The fretboard card overlaps the controls panel below it.
2. Tab/fretboard fingerings can disagree with the generated voicings shown on the keyboard — the fingering optimizer octave-shifts or re-voices chords that are unplayable as generated (e.g. the opening Bmaj7 voicing), and the resulting shapes aren't voicings a guitarist would choose. The generation and guitar views need a way to stay in sync.

Verified in the browser: only Keyboard and Notation buttons render, no console errors. 42/42 tests, tsc/eslint/build clean.