### PR TITLE
Constrain generation to guitar-playable voicings; re-enable guitar views

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -109,8 +109,10 @@ function ChartRoute() {
           </>
         )}
 
-        {/* Invisible div to maintain height */}
-        <div className="invisible">
+        {/* Invisible div to maintain height. The min-height covers the
+            tallest overlay pane (the 120px guitar cards plus their bottom
+            margin), which can exceed the keyboard's height. */}
+        <div className="invisible" style={{ minHeight: '128px' }}>
           <PianoKeyboard activeNotes={[]} />
         </div>
       </div>

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -1,8 +1,6 @@
 // Feature flags
 
-// Guitar tab + fretboard views are hidden while known issues are resolved:
-// the fretboard card overlaps the controls panel, and the tab/fretboard
-// fingerings can fall out of sync with the generated voicings shown on the
-// keyboard (the fingering optimizer octave-shifts or re-voices chords that
-// are unplayable as generated). Flip to true to work on them locally.
-export const SHOW_GUITAR_VIEWS = false
+// Guitar tab + fretboard display views. The voice-leading generator only
+// picks guitar-playable voicings (see isGuitarPlayable), so these views
+// always show the same chords as the keyboard and notation.
+export const SHOW_GUITAR_VIEWS = true

--- a/src/common/utils/graphUtils.ts
+++ b/src/common/utils/graphUtils.ts
@@ -15,7 +15,8 @@ export function buildVoiceLeadingGraph(
   costFunction: (
     currentNotes: number[],
     nextNotes: number[]
-  ) => number = calculateVoiceLeadingCost
+  ) => number = calculateVoiceLeadingCost,
+  voicingFilter?: (midiNotes: number[]) => boolean
 ): VoiceLeadingGraph {
   if (!chords.length) {
     return { nodes: [], edges: [] }
@@ -27,38 +28,56 @@ export function buildVoiceLeadingGraph(
   const COST_THRESHOLD = 0.0001
   const SAME_CHORD_PENALTY = 0.001
 
+  // Candidate voicings per chord, restricted by the filter when one is
+  // given (e.g. to guitar-playable voicings). If the filter would leave a
+  // chord with nothing, fall back to the unfiltered set so a path always
+  // exists.
+  const voicingCache = new Map<
+    ChordName,
+    Array<{ inversion: Inversion; midiNotes: number[] }>
+  >()
+  const voicingsForChord = (chord: ChordName) => {
+    const cached = voicingCache.get(chord)
+    if (cached) return cached
+
+    const all: Array<{ inversion: Inversion; midiNotes: number[] }> = []
+    for (const inversion of triads[chord]) {
+      const notes = inversion.split(' ')
+      for (const midiNotes of findAllTriadsInRange(notes, midiRange)) {
+        all.push({ inversion, midiNotes })
+      }
+    }
+    const playable = voicingFilter
+      ? all.filter(v => voicingFilter(v.midiNotes))
+      : all
+    const result = playable.length ? playable : all
+
+    voicingCache.set(chord, result)
+    return result
+  }
+
   const lastChord = chords[chords.length - 1]
   const phantomNodes: GraphNode[] = []
 
-  for (const inversion of triads[lastChord]) {
-    const notes = inversion.split(' ')
-    const midiCombinations = findAllTriadsInRange(notes, midiRange)
-
-    for (const midiNotes of midiCombinations) {
-      phantomNodes.push({
-        position: -1, // Phantom position
-        chordName: lastChord,
-        inversion,
-        midiNotes,
-      })
-    }
+  for (const { inversion, midiNotes } of voicingsForChord(lastChord)) {
+    phantomNodes.push({
+      position: -1, // Phantom position
+      chordName: lastChord,
+      inversion,
+      midiNotes,
+    })
   }
 
   // Build nodes for each position
   for (let i = 0; i < chords.length; i++) {
     const chord = chords[i]
-    for (const inversion of triads[chord]) {
-      const notes = inversion.split(' ')
-      const midiCombinations = findAllTriadsInRange(notes, midiRange)
-
-      for (const midiNotes of midiCombinations) {
-        nodes.push({
-          position: i,
-          chordName: chord,
-          inversion,
-          midiNotes,
-        })
-      }
+    for (const { inversion, midiNotes } of voicingsForChord(chord)) {
+      nodes.push({
+        position: i,
+        chordName: chord,
+        inversion,
+        midiNotes,
+      })
     }
   }
 
@@ -270,7 +289,8 @@ export function generateOptimalVoiceLeadingSequence(
   triads: { [key: string]: Inversion[] },
   voiceWeights:
     | { bass: boolean; middle: boolean; high: boolean }
-    | boolean[]
+    | boolean[],
+  voicingFilter?: (midiNotes: number[]) => boolean
 ): Triad[] {
   if (!chords.length) {
     return []
@@ -283,7 +303,13 @@ export function generateOptimalVoiceLeadingSequence(
   const costFunction = (currentNotes: number[], nextNotes: number[]) =>
     calculateVoiceLeadingCostWithWeightsN(currentNotes, nextNotes, selections)
 
-  const graph = buildVoiceLeadingGraph(chords, midiRange, triads, costFunction)
+  const graph = buildVoiceLeadingGraph(
+    chords,
+    midiRange,
+    triads,
+    costFunction,
+    voicingFilter
+  )
 
   // Use phantom nodes as start nodes and actual end nodes
   const phantomNodes = graph.nodes.filter(node => node.position === -1)

--- a/src/common/utils/tabUtils.test.ts
+++ b/src/common/utils/tabUtils.test.ts
@@ -1,9 +1,15 @@
 import { describe, it, expect } from 'vitest'
 import {
   generateTabSequence,
+  isGuitarPlayable,
   STANDARD_TUNING,
   TabFingering,
 } from './tabUtils'
+import {
+  generateSeventhChords,
+  generateTriads,
+} from './chordUtils'
+import { generateOptimalVoiceLeadingSequence } from './graphUtils'
 
 const soundedNotes = (fingering: TabFingering): number[] =>
   fingering.flatMap((fret, string) =>
@@ -185,5 +191,75 @@ describe('generateTabSequence', () => {
 
   it('returns an empty array for an empty sequence', () => {
     expect(generateTabSequence([])).toEqual([])
+  })
+})
+
+describe('isGuitarPlayable', () => {
+  it('accepts voicings with a closed shape at pitch or an octave up', () => {
+    expect(isGuitarPlayable([48, 52, 55])).toBe(true) // C major triad
+    expect(isGuitarPlayable([42, 51, 59])).toBe(true) // open Bmaj7 triad
+    expect(isGuitarPlayable([42, 47, 51, 58])).toBe(true) // drop-2 style Bmaj7
+  })
+
+  it('rejects close-position clusters that need more strings than exist', () => {
+    // A#2 B2 D#3 F#3 — the keyboard cluster the generator used to pick
+    expect(isGuitarPlayable([46, 47, 51, 54])).toBe(false)
+  })
+
+  it('rejects voicings only fingerable with open strings ringing', () => {
+    // D3 F#3 G3 B3 is "playable" only as frets 10/9 against two open
+    // strings — not a real shape
+    expect(isGuitarPlayable([50, 54, 55, 59])).toBe(false)
+  })
+})
+
+describe('guitar-constrained generation stays in sync with the tab', () => {
+  const chords = ['Bmaj7', 'D7', 'Gmaj7', 'Bb7', 'Ebmaj7', 'Am7', 'D7', 'Gmaj7']
+
+  const modes = [
+    {
+      name: 'open triads',
+      voicings: Object.fromEntries(
+        chords.map(c => [c, generateTriads(c, 'open')])
+      ),
+      weights: [true, true, true],
+    },
+    {
+      name: 'seventh chords',
+      voicings: Object.fromEntries(
+        chords.map(c => [c, generateSeventhChords(c, 'all')])
+      ),
+      weights: [true, true, true, true],
+    },
+  ]
+
+  modes.forEach(({ name, voicings, weights }) => {
+    it(`every generated ${name} voicing renders faithfully in the tab`, () => {
+      const seq = generateOptimalVoiceLeadingSequence(
+        chords,
+        [40, 76],
+        voicings,
+        weights,
+        isGuitarPlayable
+      )
+      expect(seq.length).toBe(chords.length)
+
+      const tabs = generateTabSequence(seq.map(t => t.midiNotes))
+      seq.forEach((triad, i) => {
+        const fingering = tabs[i]
+        expect(fingering).not.toBeNull()
+        const sounded = soundedNotes(fingering!).sort((a, b) => a - b)
+        // The tab plays the generated voicing exactly, at pitch or in the
+        // written guitar register an octave up — never re-voiced
+        const faithful =
+          JSON.stringify(sounded) === JSON.stringify(triad.midiNotes) ||
+          JSON.stringify(sounded) ===
+            JSON.stringify(triad.midiNotes.map(n => n + 12))
+        expect(faithful).toBe(true)
+        // and as a closed shape within a normal hand span
+        expect(fingering!.includes(0)).toBe(false)
+        expect(fretSpan(fingering!)).toBeLessThanOrEqual(4)
+      })
+    })
   })
 })

--- a/src/common/utils/tabUtils.ts
+++ b/src/common/utils/tabUtils.ts
@@ -198,31 +198,60 @@ function revoicedPitchSets(midiNotes: number[]): number[][] {
   return [...sets.values()]
 }
 
-// Candidate fingerings for one chord. All faithfulness tiers compete in a
-// single pool — the exact voicing costs nothing extra, an octave shift or a
-// re-voicing carries a penalty — so a closed re-voiced shape can still beat
-// an exact voicing that is only playable with open strings or an awkward
-// stretch.
+const inGuitarRange = (notes: number[]): boolean =>
+  notes.every(n => n >= LOWEST_NOTE && n <= HIGHEST_NOTE)
+
+// Whether a voicing can be played as-is on the fretboard — in the written
+// guitar register (an octave up) or at pitch — within a normal hand span,
+// as a closed (fully fretted, movable) shape. Requiring a closed shape
+// rules out technically-fingerable degenerates like a barre at the 10th
+// fret ringing against open strings. The voice-leading generator uses this
+// to only pick voicings the tab can render without altering them.
+export function isGuitarPlayable(midiNotes: number[]): boolean {
+  const hasClosedShape = (notes: number[]): boolean =>
+    findCandidates(notes, 4).some(c => c.frets.every(f => f > 0))
+
+  if (hasClosedShape(midiNotes)) return true
+  const octaveUp = midiNotes.map(n => n + 12)
+  return inGuitarRange(octaveUp) && hasClosedShape(octaveUp)
+}
+
+// Candidate fingerings for one chord. Pitch-faithful shapes (the exact
+// voicing, or the exact voicing in the written guitar register an octave
+// up) always win over re-voicings: re-voiced pitch sets are only
+// considered when no faithful shape is playable at all, so a chord that
+// passes isGuitarPlayable is guaranteed to render with its own notes.
 function candidatesForChord(midiNotes: number[]): Candidate[] {
   const octaveUp = midiNotes.map(n => n + 12)
-  const inRange = (notes: number[]) =>
-    notes.every(n => n >= LOWEST_NOTE && n <= HIGHEST_NOTE)
   const originalAvg = average(midiNotes)
 
-  const poolAtSpan = (maxSpan: number): Candidate[] => [
+  const faithfulAtSpan = (maxSpan: number): Candidate[] => [
     // The written-pitch register (an octave up) is the guitar default
-    ...(inRange(octaveUp) ? tag(findCandidates(octaveUp, maxSpan), 0, 12) : []),
+    ...(inGuitarRange(octaveUp)
+      ? tag(findCandidates(octaveUp, maxSpan), 0, 12)
+      : []),
     ...tag(findCandidates(midiNotes, maxSpan), AT_PITCH_PENALTY, 0),
-    ...revoicedPitchSets(midiNotes).flatMap(set =>
-      tag(findCandidates(set, maxSpan), REVOICE_PENALTY, average(set) - originalAvg)
-    ),
   ]
+  const revoicedAtSpan = (maxSpan: number): Candidate[] =>
+    revoicedPitchSets(midiNotes).flatMap(set =>
+      tag(findCandidates(set, maxSpan), REVOICE_PENALTY, average(set) - originalAvg)
+    )
 
-  // Allow an uncomfortable 5-fret stretch only when nothing else exists
-  const pool = poolAtSpan(4)
-  const found = pool.length ? pool : poolAtSpan(5)
-  // Keep the DP small: only the most playable shapes matter
-  return found.sort((a, b) => a.cost - b.cost).slice(0, 24)
+  // Allow an uncomfortable 5-fret stretch before altering any pitches
+  const tiers = [
+    () => faithfulAtSpan(4),
+    () => faithfulAtSpan(5),
+    () => revoicedAtSpan(4),
+    () => revoicedAtSpan(5),
+  ]
+  for (const tier of tiers) {
+    const found = tier()
+    if (found.length) {
+      // Keep the DP small: only the most playable shapes matter
+      return found.sort((a, b) => a.cost - b.cost).slice(0, 24)
+    }
+  }
+  return []
 }
 
 // Assign a fingering to every chord in the sequence: Viterbi over per-chord

--- a/src/services/audioService.ts
+++ b/src/services/audioService.ts
@@ -7,6 +7,7 @@ import {
   VoiceLeadingState,
 } from '../common/types'
 import { generateOptimalVoiceLeadingSequence } from '../common/utils/graphUtils'
+import { isGuitarPlayable } from '../common/utils/tabUtils'
 import {
   generateSeventhChords,
   generateTriads,
@@ -588,11 +589,14 @@ export class AudioService {
           ]
         : [voiceLeadingState.bass, voiceLeadingState.middle, voiceLeadingState.high]
 
+    // Only voice-lead through guitar-playable voicings so the keyboard,
+    // notation, tab, and fretboard views all describe the same chords.
     this.currentSequence = generateOptimalVoiceLeadingSequence(
       this.currentChordNames,
       midiRange,
       this.currentTriads,
-      selections
+      selections,
+      isGuitarPlayable
     )
     return this.currentSequence
   }


### PR DESCRIPTION
Implements option 1 from the sync discussion: guitar playability is now a first-class constraint in voice-leading generation, so the keyboard, audio, notation, tab, and fretboard all describe the same voicings.

## How it works

- `isGuitarPlayable(midiNotes)` (exported from tabUtils) requires a **closed** (fully fretted, movable) fingering within a 4-fret span, at pitch or an octave up. Requiring closed shapes also rejects technically-fingerable degenerates — e.g. Gmaj7 voiced D3-F#3-G3-B3 is "fingerable" only as a 9th/10th-fret shape ringing against two open strings, which no one would play.
- `buildVoiceLeadingGraph` accepts a voicing filter and applies it when enumerating candidate voicings per chord, with a fallback to the unfiltered set if a chord would be left empty (so a path always exists). Voicing sets are cached per chord name.
- The tab's re-voice tier is now strictly last-resort: pitch-faithful shapes (exact, or exact an octave up in written guitar register) always win when they exist, so a chord that passes the filter is **guaranteed** to render with its own notes.

## Results on Giant Steps (32 chords)

|  | voice movement | faithful | re-voiced | open strings |
|---|---|---|---|---|
| Triads (before → after) | 165 → **165** (unchanged) | 32/32 | 0 | 0 |
| Sevenths (before → after) | 133 → 147 (+10%) | **32/32, uniform register** | 0 (was 12) | 0 |

Seventh mode is the big win: instead of unplayable keyboard clusters (Bmaj7 as A#2-B2-D#3-F#3), the optimizer now picks real guitar voicings (Bmaj7 as F#2-B2-D#3-A#3, a drop-2-style spread) — the same notes light up on the keyboard and appear in the tab/fretboard.

## Also

- **Fixed the display-pane overlap**: the invisible keyboard spacer reserved 100px while the guitar cards need 128px; it now has a matching min-height.
- **Re-enabled the guitar views** (`SHOW_GUITAR_VIEWS = true`) since both issues it was guarding are fixed. One-line revert if more QA time is wanted.

## Verification

- New tests: `isGuitarPlayable` accepts real shapes / rejects clusters and open-string-only degenerates; end-to-end sync tests assert every generated voicing (both modes) renders faithfully as a closed shape within a 4-fret span. Suite: 47/47, tsc/eslint/build clean.
- Browser-verified: keyboard and tab show the same Bmaj7 structure in both modes, fretboard clears the controls panel by 16px, no console errors.