### PR TITLE
Exclude staircase grips; cycle voicings over static chords

### DIFF
--- a/src/common/utils/graphUtils.ts
+++ b/src/common/utils/graphUtils.ts
@@ -283,6 +283,72 @@ export function calculateVoiceLeadingCostWithWeightsN(
   return activeVoices > 0 ? totalCost / activeVoices : totalCost
 }
 
+// Several bars of a static chord would otherwise settle into an A-B-A-B
+// alternation (pairwise-optimal, but dull). For runs of the same chord
+// three bars or longer, re-pick the interior voicings as a walk through
+// voicings that haven't been used yet in the run: each step moves to the
+// nearest unused voicing, and the final step also weighs the transition
+// into the next chord so the run still exits cleanly. The run's entry
+// voicing (chosen by the global optimization) is kept.
+function diversifyStaticRuns(
+  path: Triad[],
+  nodes: GraphNode[],
+  costFunction: (currentNotes: number[], nextNotes: number[]) => number
+): void {
+  const key = (midiNotes: number[]) => midiNotes.join(',')
+
+  let start = 0
+  while (start < path.length) {
+    let end = start
+    while (
+      end + 1 < path.length &&
+      path[end + 1].chordName === path[start].chordName
+    ) {
+      end++
+    }
+
+    if (end - start + 1 >= 3) {
+      const used = new Set([key(path[start].midiNotes)])
+
+      for (let i = start + 1; i <= end; i++) {
+        const candidates = nodes.filter(node => node.position === i)
+        const fresh = candidates.filter(c => !used.has(key(c.midiNotes)))
+        // If the chord has fewer voicings than the run has bars, allow
+        // reuse — but never repeat the immediately preceding voicing
+        const pool = fresh.length
+          ? fresh
+          : candidates.filter(
+              c => key(c.midiNotes) !== key(path[i - 1].midiNotes)
+            )
+        const options = pool.length ? pool : candidates
+
+        const exit = i === end && i + 1 < path.length ? path[i + 1] : null
+        let best = options[0]
+        let bestCost = Infinity
+        for (const candidate of options) {
+          let cost = costFunction(path[i - 1].midiNotes, candidate.midiNotes)
+          if (exit) {
+            cost += costFunction(candidate.midiNotes, exit.midiNotes)
+          }
+          if (cost < bestCost) {
+            bestCost = cost
+            best = candidate
+          }
+        }
+
+        path[i] = {
+          chordName: best.chordName,
+          inversion: best.inversion,
+          midiNotes: best.midiNotes,
+        }
+        used.add(key(best.midiNotes))
+      }
+    }
+
+    start = end + 1
+  }
+}
+
 export function generateOptimalVoiceLeadingSequence(
   chords: ChordName[],
   midiRange: [number, number],
@@ -318,5 +384,10 @@ export function generateOptimalVoiceLeadingSequence(
   )
 
   const path = findOptimalVoiceLeading(graph, phantomNodes, endNodes)
-  return path.length ? path : []
+  if (!path.length) {
+    return []
+  }
+
+  diversifyStaticRuns(path, graph.nodes, costFunction)
+  return path
 }

--- a/src/common/utils/seventhChords.test.ts
+++ b/src/common/utils/seventhChords.test.ts
@@ -222,6 +222,46 @@ describe('end-to-end 4-voice optimization', () => {
     expect(totalMovement).toBeLessThan(30)
   })
 
+  it('cycles through distinct voicings over a static chord', () => {
+    const staticChords = ['Gm6', 'Gm6', 'Gm6', 'Gm6']
+    const staticVoicings = Object.fromEntries(
+      staticChords.map(c => [c, generateSeventhChords(c, 'all')])
+    )
+    const seq = generateOptimalVoiceLeadingSequence(
+      staticChords,
+      MIDI_RANGE,
+      staticVoicings,
+      [true, true, true, true]
+    )
+    expect(seq.length).toBe(4)
+    const distinct = new Set(seq.map(t => t.midiNotes.join(',')))
+    expect(distinct.size).toBe(4)
+  })
+
+  it('keeps a static run leading cleanly into the following chord', () => {
+    const runChords = ['Gm6', 'Gm6', 'Gm6', 'Gm6', 'C9']
+    const runVoicings = Object.fromEntries(
+      runChords.map(c => [c, generateSeventhChords(c, 'all')])
+    )
+    const seq = generateOptimalVoiceLeadingSequence(
+      runChords,
+      MIDI_RANGE,
+      runVoicings,
+      [true, true, true, true]
+    )
+    expect(seq.length).toBe(5)
+    const gm6s = seq.slice(0, 4)
+    expect(new Set(gm6s.map(t => t.midiNotes.join(','))).size).toBe(4)
+    // The last Gm6 still hands off to C9 without a huge leap
+    const last = seq[3].midiNotes
+    const next = seq[4].midiNotes
+    let movement = 0
+    for (let v = 0; v < Math.min(last.length, next.length); v++) {
+      movement += Math.abs(next[v] - last[v])
+    }
+    expect(movement).toBeLessThan(24)
+  })
+
   it('respects voice selection: pinning bass produces less bass movement', () => {
     const balanced = generateOptimalVoiceLeadingSequence(
       chords,

--- a/src/common/utils/tabUtils.test.ts
+++ b/src/common/utils/tabUtils.test.ts
@@ -211,6 +211,15 @@ describe('isGuitarPlayable', () => {
     // strings — not a real shape
     expect(isGuitarPlayable([50, 54, 55, 59])).toBe(false)
   })
+
+  it('rejects four-finger staircase grips (four distinct frets over a 4-fret span)', () => {
+    // Close root-position D7 (D3 F#3 A3 C4) only fits as x5421x —
+    // four fingers on four different frets, impractically awkward
+    expect(isGuitarPlayable([50, 54, 57, 60])).toBe(false)
+    // But four distinct frets within a 3-fret span is a normal jazz
+    // grip (e.g. Gmaj7 drop-2 at 9-11-8-10) and stays playable
+    expect(isGuitarPlayable([47, 54, 55, 62])).toBe(true)
+  })
 })
 
 describe('guitar-constrained generation stays in sync with the tab', () => {

--- a/src/common/utils/tabUtils.ts
+++ b/src/common/utils/tabUtils.ts
@@ -113,7 +113,13 @@ function findCandidates(midiNotes: number[], maxSpan: number): Candidate[] {
       const span = fretted.length
         ? Math.max(...fretted) - Math.min(...fretted)
         : 0
-      if (span <= maxSpan) {
+      // A four-finger "staircase" — four distinct frets spread over four
+      // or more — is impractically awkward (the close-position dominant
+      // grip x5421x). Four distinct frets within a 3-fret span is a
+      // normal jazz shape and stays legal.
+      const staircase =
+        new Set(fretted).size >= 4 && span >= 4
+      if (span <= maxSpan && !staircase) {
         candidates.push({
           strings: [...acc],
           frets,


### PR DESCRIPTION
Two comping improvements from playing feedback:

## No more staircase grips

The close-position root-on-A-string dominant shape (D7 as `x5421x`) is four fingers on four different frets over a 4-fret span — no barre possible, maximal stretch. The fingering enumerator now rejects any shape with **4+ distinct frets AND span ≥ 4**. Four distinct frets within a 3-fret span (normal jazz grips like a drop-2 at 9-11-8-10) stays legal.

Because `isGuitarPlayable` shares this code, generation stops picking close root-position dominant voicings entirely. Nice side effect: the Giant Steps seventh-mode optimum improved — total voice movement now matches the unconstrained optimum (133, was 147).

## Static chords cycle through voicings

Four bars of Gm6 used to alternate A-B-A-B (pairwise-optimal, but dull). Runs of the same chord (3+ bars) now walk through distinct voicings: each interior bar moves to the nearest voicing not yet used in the run, and the final bar also weighs the hand-off into the next chord. The run's entry voicing keeps the globally optimal choice. Example — Gm6 ×4 → C9:

```
Gm6  E3 G3 Bb3 D4    x-7-5-3-3-x
Gm6  D3 G3 Bb3 E4    x-5-5-3-5-x
Gm6  E3 Bb3 D4 G4    x-x-2-3-3-3
Gm6  Bb2 E3 G3 D4    6-7-5-7-x-x
C9   C3 E3 Bb3 D4    8-7-8-7-x-x   <- smooth exit
```

Runs of 2 already alternate two distinct voicings and are unchanged; Giant Steps (which has only length-2 repeats) is unaffected in triad mode.

## Verification

- New tests: staircase rejection (and the 3-fret-span counter-example), 4× static chord produces 4 distinct voicings, and the run's exit transition stays small. Suite: 54/54, tsc/eslint/build clean.
- Debug sweeps: zero staircase grips across generated charts; 9.20 Special still 24/24 faithful; browser check clean.