### PR TITLE
Pin the close-maj7 staircase grip as playable

### DIFF
--- a/src/common/utils/tabUtils.test.ts
+++ b/src/common/utils/tabUtils.test.ts
@@ -220,6 +220,16 @@ describe('isGuitarPlayable', () => {
     // grip (e.g. Gmaj7 drop-2 at 9-11-8-10) and stays playable
     expect(isGuitarPlayable([47, 54, 55, 62])).toBe(true)
   })
+
+  it('keeps the consecutive close-maj7 staircase (spans only 3 frets)', () => {
+    // Ebmaj7 close root position (Eb4 G4 Bb4 D5) is the classic
+    // x-x-13-12-11-10 diagonal: four distinct frets but consecutive,
+    // so the span is 3 and fingers 4-3-2-1 fall onto it naturally.
+    const ebmaj7 = [63, 67, 70, 74]
+    expect(isGuitarPlayable(ebmaj7)).toBe(true)
+    const [fingering] = generateTabSequence([ebmaj7])
+    expect(fingering).toEqual([null, null, 13, 12, 11, 10])
+  })
 })
 
 describe('guitar-constrained generation stays in sync with the tab', () => {

--- a/src/common/utils/tabUtils.ts
+++ b/src/common/utils/tabUtils.ts
@@ -115,8 +115,10 @@ function findCandidates(midiNotes: number[], maxSpan: number): Candidate[] {
         : 0
       // A four-finger "staircase" — four distinct frets spread over four
       // or more — is impractically awkward (the close-position dominant
-      // grip x5421x). Four distinct frets within a 3-fret span is a
-      // normal jazz shape and stays legal.
+      // grip x5421x, whose 4-3-3 stack forces a gapped 5-4-2-1 reach).
+      // Four distinct frets within a 3-fret span stays legal: the
+      // consecutive diagonal of a close maj7 (x-x-13-12-11-10) spans
+      // only 3 and falls naturally under fingers 4-3-2-1.
       const staircase =
         new Set(fretted).size >= 4 && span >= 4
       if (span <= maxSpan && !staircase) {


### PR DESCRIPTION
Follow-up to #13: confirms the staircase rejection does **not** exclude the close-position maj7 diagonal (`Ebmaj7` as `x-x-13-12-11-10`) — that shape's four distinct frets are consecutive, spanning only 3, so the span ≥ 4 condition never fires and it renders as-is (verified: `generateTabSequence([[63,67,70,74]])` returns exactly `[null,null,13,12,11,10]`).

The geometry separates the two grips without special-casing: a maj7's 4-3-4 stack against the D-G-B-e tuning gives fret deltas of −1,−1,−1 (consecutive diagonal, span 3, natural under fingers 4-3-2-1), while the dominant's 4-3-3 stack against A-D-G-B gives −1,−2,−1 → the gapped `5-4-2-1` reach spanning 4.

Adds a regression test pinning the maj7 shape and expands the code comment. 55/55 tests.